### PR TITLE
Added implementation for resolc trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2998,6 +2998,7 @@ name = "revive-dt-compiler"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "log",
  "revive-common",
  "revive-solc-json-interface",
  "semver 1.0.26",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3000,6 +3000,8 @@ dependencies = [
  "anyhow",
  "log",
  "revive-common",
+ "revive-dt-config",
+ "revive-dt-solc-binaries",
  "revive-solc-json-interface",
  "semver 1.0.26",
  "serde_json",

--- a/crates/compiler/Cargo.toml
+++ b/crates/compiler/Cargo.toml
@@ -11,6 +11,8 @@ rust-version.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 revive-solc-json-interface = { workspace = true }
+revive-dt-config = { workspace = true }
+revive-dt-solc-binaries = { workspace = true }
 revive-common = { workspace = true }
 semver = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/compiler/Cargo.toml
+++ b/crates/compiler/Cargo.toml
@@ -14,3 +14,4 @@ revive-solc-json-interface = { workspace = true }
 revive-common = { workspace = true }
 semver = { workspace = true }
 serde_json = { workspace = true }
+log = { workspace = true }

--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -4,7 +4,9 @@
 //! - Polkadot revive Wasm compiler
 
 use std::{
-    fs::read_to_string, hash::Hash, path::{Path, PathBuf}
+    fs::read_to_string,
+    hash::Hash,
+    path::{Path, PathBuf},
 };
 
 use revive_dt_config::Arguments;

--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -4,10 +4,10 @@
 //! - Polkadot revive Wasm compiler
 
 use std::{
-    fs::read_to_string,
-    hash::Hash,
-    path::{Path, PathBuf},
+    fs::read_to_string, hash::Hash, path::{Path, PathBuf}
 };
+
+use revive_dt_config::Arguments;
 
 use revive_common::EVMVersion;
 use revive_solc_json_interface::{
@@ -33,6 +33,8 @@ pub trait SolidityCompiler {
     ) -> anyhow::Result<CompilerOutput<Self::Options>>;
 
     fn new(solc_executable: PathBuf) -> Self;
+
+    fn get_compiler_executable(config: &Arguments, version: Version) -> anyhow::Result<PathBuf>;
 }
 
 /// The generic compilation input configuration.

--- a/crates/compiler/src/revive_resolc.rs
+++ b/crates/compiler/src/revive_resolc.rs
@@ -1,2 +1,49 @@
-//! Implements the [crate::SolidityCompiler] trait with resolc for
-//! compiling contracts to PVM bytecode.
+//! Implements the [SolidityCompiler] trait with `resolc` for
+//! compiling contracts to PolkaVM (PVM) bytecode.
+
+use std::{
+    path::PathBuf,
+    process::{Command, Stdio},
+};
+
+use crate::{CompilerInput, CompilerOutput, SolidityCompiler};
+use revive_solc_json_interface::SolcStandardJsonOutput;
+
+/// A wrapper around the `resolc` binary, emitting PVM-compatible bytecode.
+pub struct Resolv {
+    /// Path to the `resolc` executable
+    resolc_path: PathBuf,
+}
+
+impl SolidityCompiler for Resolv {
+    /// No extra compiler options for now.
+    type Options = ();
+
+    fn build(
+        &self,
+        input: CompilerInput<Self::Options>,
+    ) -> anyhow::Result<CompilerOutput<Self::Options>> {
+
+        let mut child = Command::new(&self.resolc_path)
+            .arg("--standard-json")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())   // show errors directly
+            .spawn()?;
+
+        serde_json::to_writer(
+            child.stdin.as_mut().expect("stdin must be piped"),
+            &input.input,
+        )?;
+
+        let stdout = child.wait_with_output()?.stdout;
+
+        let output: SolcStandardJsonOutput = serde_json::from_slice(&stdout)?;
+
+        Ok(CompilerOutput { input, output })
+    }
+
+    fn new(resolc_path: PathBuf) -> Self {
+        Resolv { resolc_path }
+    }
+}

--- a/crates/compiler/src/revive_resolc.rs
+++ b/crates/compiler/src/revive_resolc.rs
@@ -8,6 +8,7 @@ use std::{
 
 use crate::{CompilerInput, CompilerOutput, SolidityCompiler};
 use revive_solc_json_interface::SolcStandardJsonOutput;
+use revive_dt_config::Arguments;
 
 /// A wrapper around the `resolc` binary, emitting PVM-compatible bytecode.
 pub struct Resolc {
@@ -56,5 +57,13 @@ impl SolidityCompiler for Resolc {
 
     fn new(resolc_path: PathBuf) -> Self {
         Resolc { resolc_path }
+    }
+    
+    fn get_compiler_executable(config: &Arguments, _version: semver::Version) -> anyhow::Result<PathBuf> {
+        if !config.resolc.as_os_str().is_empty() {
+            return Ok(config.resolc.clone());
+        }
+
+        Ok(PathBuf::from("resolc"))
     }
 }

--- a/crates/compiler/src/revive_resolc.rs
+++ b/crates/compiler/src/revive_resolc.rs
@@ -7,8 +7,8 @@ use std::{
 };
 
 use crate::{CompilerInput, CompilerOutput, SolidityCompiler};
-use revive_solc_json_interface::SolcStandardJsonOutput;
 use revive_dt_config::Arguments;
+use revive_solc_json_interface::SolcStandardJsonOutput;
 
 /// A wrapper around the `resolc` binary, emitting PVM-compatible bytecode.
 pub struct Resolc {
@@ -23,7 +23,6 @@ impl SolidityCompiler for Resolc {
         &self,
         input: CompilerInput<Self::Options>,
     ) -> anyhow::Result<CompilerOutput<Self::Options>> {
-
         let mut child = Command::new(&self.resolc_path)
             .arg("--standard-json")
             .args(&input.extra_options)
@@ -32,9 +31,9 @@ impl SolidityCompiler for Resolc {
             .stderr(Stdio::piped())
             .spawn()?;
 
-        let mut stdin_pipe = child.stdin.as_mut().expect("stdin must be piped");
-        serde_json::to_writer(&mut stdin_pipe, &input.input)?;
-        
+        let stdin_pipe = child.stdin.as_mut().expect("stdin must be piped");
+        serde_json::to_writer(stdin_pipe, &input.input)?;
+
         let json_in = serde_json::to_string_pretty(&input.input)?;
 
         let output = child.wait_with_output()?;
@@ -42,24 +41,35 @@ impl SolidityCompiler for Resolc {
         let stderr = output.stderr;
 
         if !output.status.success() {
-            log::error!("resolc failed exit={} stderr={} JSON-in={} ",
+            log::error!(
+                "resolc failed exit={} stderr={} JSON-in={} ",
                 output.status,
                 String::from_utf8_lossy(&stderr),
                 json_in,
             );
         }
 
-        let parsed: SolcStandardJsonOutput = serde_json::from_slice(&stdout)
-            .map_err(|e| anyhow::anyhow!("failed to parse resolc JSON output: {e}\nstderr: {}", String::from_utf8_lossy(&stderr)))?;
+        let parsed: SolcStandardJsonOutput = serde_json::from_slice(&stdout).map_err(|e| {
+            anyhow::anyhow!(
+                "failed to parse resolc JSON output: {e}\nstderr: {}",
+                String::from_utf8_lossy(&stderr)
+            )
+        })?;
 
-        Ok(CompilerOutput { input, output: parsed })
+        Ok(CompilerOutput {
+            input,
+            output: parsed,
+        })
     }
 
     fn new(resolc_path: PathBuf) -> Self {
         Resolc { resolc_path }
     }
-    
-    fn get_compiler_executable(config: &Arguments, _version: semver::Version) -> anyhow::Result<PathBuf> {
+
+    fn get_compiler_executable(
+        config: &Arguments,
+        _version: semver::Version,
+    ) -> anyhow::Result<PathBuf> {
         if !config.resolc.as_os_str().is_empty() {
             return Ok(config.resolc.clone());
         }

--- a/crates/compiler/src/solc.rs
+++ b/crates/compiler/src/solc.rs
@@ -41,8 +41,11 @@ impl SolidityCompiler for Solc {
     fn new(solc_path: PathBuf) -> Self {
         Self { solc_path }
     }
-    
-    fn get_compiler_executable(config: &Arguments, version: semver::Version) -> anyhow::Result<PathBuf> {
+
+    fn get_compiler_executable(
+        config: &Arguments,
+        version: semver::Version,
+    ) -> anyhow::Result<PathBuf> {
         let path = download_solc(config.directory(), version, config.wasm)?;
         Ok(path)
     }

--- a/crates/compiler/src/solc.rs
+++ b/crates/compiler/src/solc.rs
@@ -7,6 +7,8 @@ use std::{
 };
 
 use crate::{CompilerInput, CompilerOutput, SolidityCompiler};
+use revive_dt_config::Arguments;
+use revive_dt_solc_binaries::download_solc;
 
 pub struct Solc {
     solc_path: PathBuf,
@@ -38,5 +40,10 @@ impl SolidityCompiler for Solc {
 
     fn new(solc_path: PathBuf) -> Self {
         Self { solc_path }
+    }
+    
+    fn get_compiler_executable(config: &Arguments, version: semver::Version) -> anyhow::Result<PathBuf> {
+        let path = download_solc(config.directory(), version, config.wasm)?;
+        Ok(path)
     }
 }

--- a/crates/core/src/driver/mod.rs
+++ b/crates/core/src/driver/mod.rs
@@ -42,23 +42,18 @@ where
 
         let sources = metadata.contract_sources()?;
         let base_path = metadata.directory()?.display().to_string();
-        log::info!("base path is: {} ", base_path.clone());
 
         let mut compiler = Compiler::<T::Compiler>::new().base_path(base_path.clone());
         for (file, _contract) in sources.values() {
-            log::info!("contract source {}", file.display());
+            log::debug!("contract source {}", file.display());
             compiler = compiler.with_source(file)?;
         }
 
         let compiler_path = T::get_compiler_executable(self.config, version)?;
-        //log::info!("Compiler selected is: {}", compiler_path.display());
 
         let output = compiler
             .solc_optimizer(mode.solc_optimize())
             .try_build(compiler_path)?;
-
-        //let json_output = serde_json::to_string_pretty(&output.output)?;
-        //log::info!("JSON to solc:\n{}", json_output);
 
         self.contracts.insert(output.input, output.output);
 

--- a/crates/core/src/driver/mod.rs
+++ b/crates/core/src/driver/mod.rs
@@ -8,7 +8,6 @@ use revive_dt_compiler::{Compiler, CompilerInput, SolidityCompiler};
 use revive_dt_config::Arguments;
 use revive_dt_format::{input::Input, metadata::Metadata, mode::SolcMode};
 use revive_dt_node_interaction::EthereumNode;
-use revive_dt_solc_binaries::download_solc;
 use revive_solc_json_interface::SolcStandardJsonOutput;
 
 use crate::Platform;
@@ -43,16 +42,23 @@ where
 
         let sources = metadata.contract_sources()?;
         let base_path = metadata.directory()?.display().to_string();
+        log::info!("base path is: {} ", base_path.clone());
+
         let mut compiler = Compiler::<T::Compiler>::new().base_path(base_path.clone());
         for (file, _contract) in sources.values() {
-            log::debug!("contract source {}", file.display());
+            log::info!("contract source {}", file.display());
             compiler = compiler.with_source(file)?;
         }
 
-        let solc_path = download_solc(self.config.directory(), version, self.config.wasm)?;
+        let compiler_path = T::get_compiler_executable(self.config, version)?;
+        //log::info!("Compiler selected is: {}", compiler_path.display());
+
         let output = compiler
             .solc_optimizer(mode.solc_optimize())
-            .try_build(solc_path)?;
+            .try_build(compiler_path)?;
+
+        //let json_output = serde_json::to_string_pretty(&output.output)?;
+        //log::info!("JSON to solc:\n{}", json_output);
 
         self.contracts.insert(output.input, output.output);
 

--- a/crates/core/src/driver/mod.rs
+++ b/crates/core/src/driver/mod.rs
@@ -49,7 +49,8 @@ where
             compiler = compiler.with_source(file)?;
         }
 
-        let compiler_path = T::get_compiler_executable(self.config, version)?;
+        let compiler_path = T::Compiler::get_compiler_executable(self.config, version)?;
+
 
         let output = compiler
             .solc_optimizer(mode.solc_optimize())

--- a/crates/core/src/driver/mod.rs
+++ b/crates/core/src/driver/mod.rs
@@ -51,7 +51,6 @@ where
 
         let compiler_path = T::Compiler::get_compiler_executable(self.config, version)?;
 
-
         let output = compiler
             .solc_optimizer(mode.solc_optimize())
             .try_build(compiler_path)?;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -4,13 +4,8 @@
 //! provides a helper utilty to execute tests.
 
 use revive_dt_compiler::{SolidityCompiler, solc, revive_resolc};
-use revive_dt_config::Arguments;
 use revive_dt_node::geth;
 use revive_dt_node_interaction::EthereumNode;
-use revive_dt_solc_binaries::download_solc;
-
-use std::path::PathBuf;
-use semver::Version;
 
 pub mod driver;
 
@@ -21,7 +16,6 @@ pub trait Platform {
     type Blockchain: EthereumNode;
     type Compiler: SolidityCompiler;
 
-    fn get_compiler_executable(config: &Arguments, version: Version) -> anyhow::Result<PathBuf>;
 }
 
 #[derive(Default)]
@@ -30,12 +24,6 @@ pub struct Geth;
 impl Platform for Geth {
     type Blockchain = geth::Instance;
     type Compiler = solc::Solc;
-    
-    fn get_compiler_executable(config: &Arguments, version: Version) -> anyhow::Result<PathBuf> {
-
-        let path = download_solc(config.directory(), version, config.wasm)?;
-        Ok(path)
-    }
 }
 
 #[derive(Default)]
@@ -44,13 +32,5 @@ pub struct Kitchensink;
 impl Platform for Kitchensink {
     type Blockchain = geth::Instance;
     type Compiler = revive_resolc::Resolc;
-    
-    fn get_compiler_executable(config: &Arguments, _version: Version) -> anyhow::Result<PathBuf> {
-
-        if !config.resolc.as_os_str().is_empty() {
-            return Ok(config.resolc.clone());
-        }
-
-        Ok(PathBuf::from("resolc"))
-    }
+   
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -3,7 +3,7 @@
 //! This crate defines the testing configuration and
 //! provides a helper utilty to execute tests.
 
-use revive_dt_compiler::{SolidityCompiler, solc, revive_resolc};
+use revive_dt_compiler::{SolidityCompiler, revive_resolc, solc};
 use revive_dt_node::geth;
 use revive_dt_node_interaction::EthereumNode;
 
@@ -15,7 +15,6 @@ pub mod driver;
 pub trait Platform {
     type Blockchain: EthereumNode;
     type Compiler: SolidityCompiler;
-
 }
 
 #[derive(Default)]
@@ -32,5 +31,4 @@ pub struct Kitchensink;
 impl Platform for Kitchensink {
     type Blockchain = geth::Instance;
     type Compiler = revive_resolc::Resolc;
-   
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -43,11 +43,14 @@ pub struct Kitchensink;
 
 impl Platform for Kitchensink {
     type Blockchain = geth::Instance;
-    type Compiler = revive_resolc::Resolv;
+    type Compiler = revive_resolc::Resolc;
     
-    fn get_compiler_executable(_config: &Arguments, _version: Version) -> anyhow::Result<PathBuf> {
+    fn get_compiler_executable(config: &Arguments, _version: Version) -> anyhow::Result<PathBuf> {
 
-        //very dummy for now, maybe we can send like an arg param, --resolcpath
+        if !config.resolc.as_os_str().is_empty() {
+            return Ok(config.resolc.clone());
+        }
+
         Ok(PathBuf::from("resolc"))
     }
 }

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -5,7 +5,8 @@ use rayon::{ThreadPoolBuilder, prelude::*};
 
 use revive_dt_config::*;
 use revive_dt_core::{
-    driver::{Driver, State}, Geth, Kitchensink
+    Geth, Kitchensink,
+    driver::{Driver, State},
 };
 use revive_dt_format::{corpus::Corpus, metadata::Metadata};
 use revive_dt_node::pool::NodePool;

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -5,8 +5,7 @@ use rayon::{ThreadPoolBuilder, prelude::*};
 
 use revive_dt_config::*;
 use revive_dt_core::{
-    Geth,
-    driver::{Driver, State},
+    driver::{Driver, State}, Geth, Kitchensink
 };
 use revive_dt_format::{corpus::Corpus, metadata::Metadata};
 use revive_dt_node::pool::NodePool;
@@ -109,11 +108,16 @@ fn main_compile_only(
 ) -> anyhow::Result<()> {
     tests.par_iter().for_each(|metadata| {
         for mode in &metadata.solc_modes() {
-            let mut state = match platform {
-                TestingPlatform::Geth => State::<Geth>::new(config),
-                _ => todo!(),
+            match platform {
+                TestingPlatform::Geth => {
+                    let mut state = State::<Geth>::new(config);
+                    let _ = state.build_contracts(mode, metadata);
+                }
+                TestingPlatform::Kitchensink => {
+                    let mut state = State::<Kitchensink>::new(config);
+                    let _ = state.build_contracts(mode, metadata);
+                }
             };
-            let _ = state.build_contracts(mode, metadata);
         }
     });
 


### PR DESCRIPTION
Added implementation for resolc trait. 

I have ran the command to compile the tests from https://github.com/matter-labs/era-compiler-tests/tree/main/solidity/complex.

```perl
RUST_LOG=info cargo run --release -p revive-dt-core -- \
  --corpus  ml-solidity-complex.json \
  --leader  geth \
  --follower kitchensink --compile-only kitchensink 2>&1 | tee runcompilesink.log
``` 

I have observed that after running the tests I see errors like this:

```
"formattedMessage": "ParserError: Source \"/Users/projects/era-compiler-tests/solidity/complex/invalid_signature/simple/icallable.sol\" not found: File outside of allowed directories. The following are allowed: \".\".\n --> /Users/projects/era-compiler-tests/solidity/complex/invalid_signature/simple/main.sol:5:1:\n  |\n5 | import \"./icallable.sol\";\n  | ^^^^^^^^^^^^^^^^^^^^^^^^^\n\n"
``` 

and other errors which have warning type (for example)

```
{
          "component": "general",
          "errorCode": "1878",
          "formattedMessage": "Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing \"SPDX-License-Identifier: <SPDX-License>\" to each source file. Use \"SPDX-License-Identifier: UNLICENSED\" for non-open-source code. Please see https://spdx.org for more information.\n--> /Users/projects/era-compiler-tests/solidity/complex/defi/UniswapV2Router01/libraries/TransferHelper.sol\n\n",
          "message": "SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing \"SPDX-License-Identifier: <SPDX-License>\" to each source file. Use \"SPDX-License-Identifier: UNLICENSED\" for non-open-source code. Please see https://spdx.org for more information.",
          "severity": "warning",
          "sourceLocation": {
            "file": "/Users/projects/era-compiler-tests/solidity/complex/defi/UniswapV2Router01/libraries/TransferHelper.sol",
            "start": -1,
            "end": -1
          },
          "type": "Warning"
        }
``` 


