### PR TITLE
Extended execute_input method

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -5,7 +5,7 @@
 
 use revive_dt_compiler::{SolidityCompiler, revive_resolc, solc};
 use revive_dt_config::TestingPlatform;
-use revive_dt_node::geth;
+use revive_dt_node::{geth, kitchensink::KitchensinkNode};
 use revive_dt_node_interaction::EthereumNode;
 
 pub mod driver;
@@ -37,7 +37,7 @@ impl Platform for Geth {
 pub struct Kitchensink;
 
 impl Platform for Kitchensink {
-    type Blockchain = geth::Instance;
+    type Blockchain = KitchensinkNode;
     type Compiler = revive_resolc::Resolc;
 
     fn config_id() -> TestingPlatform {


### PR DESCRIPTION
Extended the execute method for the Nodes, in order to be able to extract the DiffMode and the TransactionTrace. 
This pr is part of this: https://github.com/paritytech/revive-differential-tests/issues/7