### PR TITLE
Fixing the CI on Ubuntu

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,8 +102,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler
 
-          # Download and install Geth all-tools from the geth store website as the PPA only has the
-          # latest versions of Geth.
+          # We were facing some issues in CI with the 1.16.* versions of geth, and specifically on
+          # Ubuntu. Eventually, we found out that the last version of geth that worked in our CI was
+          # version 1.15.11. Thus, this is the version that we want to use in CI. The PPA sadly does
+          # not have historic versions of Geth and therefore we need to resort to downloading pre
+          # built binaries for Geth and the surrounding tools which is what the following parts of 
+          # the script do.
+
           sudo apt-get install -y wget ca-certificates tar
           ARCH=$(uname -m)
           if [ "$ARCH" = "x86_64" ]; then


### PR DESCRIPTION
## Summary

This PR fixes the CI issues that we've been seeing on Ubuntu.

## Description

We can see that the last time the CI passed on Ubuntu was in [this job](https://github.com/paritytech/revive-differential-tests/actions/runs/15779576566/job/44481697973#step:6:93) when the Geth node we were using was of the version `1.15.11+build31083+noble`. The CI then started failing in the [subsequent jobs](https://github.com/paritytech/revive-differential-tests/actions/runs/15929633926/job/44935857942#step:6:93) when Geth was updated to `1.16.0+build31227+noble`. 

A simple way for us to fix this issue is to pin the version of Geth to the last known version that worked, which is `1.15.11`.

The PPA does not contain historic versions of `Geth` so we need to rely on pre-built binaries from `https://geth.ethereum.org/downloads`

After pinning the version to `1.15.11` and running the CI it passes.