### PR TITLE
Fix function selector & argument encoding

### DIFF
--- a/crates/format/src/input.rs
+++ b/crates/format/src/input.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, str::FromStr};
+use std::collections::HashMap;
 
 use alloy::{
     json_abi::JsonAbi,
@@ -210,7 +210,7 @@ fn resolve_argument(
             .ok_or_else(|| anyhow::anyhow!("`-0` is invalid literal"))?;
         Ok(U256::MAX.checked_sub(value).expect("Always valid"))
     } else if let Some(value) = value.strip_prefix("0x") {
-        Ok(U256::from_str(value)
+        Ok(U256::from_str_radix(value, 16)
             .map_err(|error| anyhow::anyhow!("Invalid hexadecimal literal: {}", error))?)
     } else {
         // TODO: This is a set of "variables" that we need to be able to resolve to be fully in
@@ -313,7 +313,7 @@ mod tests {
             .selector()
             .0;
 
-        let input = Input {
+        let input: Input = Input {
             instance: "Contract".to_string(),
             method: Method::FunctionName("send".to_owned()),
             calldata: Some(Calldata::Compound(vec![


### PR DESCRIPTION
## Summary

This PR fixes some issues that we had in computing the function selector and in the encoding of arguments for functions

## Description

> Tl;Dr: I made the following changes in this PR:
> 1. Corrected the way in which the function selector was computed.
> 2. Changed the logic that parses the `Input.calldata -> Bytes` to align more with matterlabs, which fixed a bug I encountered. 

I encountered an issue where the function selector that we computed didn't seem to be correct as can be seen from the following logs:

```
  2025-07-13T13:37:06.060606Z ERROR revive_dt_core::driver: Failed to construct legacy transaction: Function with selector [223, 254, 173, 208] not found in ABI for the instance "Main"
    at crates/core/src/driver/mod.rs:145 on main ThreadId(1)
    in revive_dt_core::driver::Executing case with case: "first", case_idx: 0
    in retester::Running driver with metadata_file_path: "era-compiler-tests/solidity/complex/array_one_element/test.json"

  2025-07-13T13:37:06.060626Z ERROR revive_dt_core::driver: Leader execution failed for Main: Function with selector [223, 254, 173, 208] not found in ABI for the instance "Main"
    at crates/core/src/driver/mod.rs:476 on main ThreadId(1)
    in revive_dt_core::driver::Executing case with case: "first", case_idx: 0
    in retester::Running driver with metadata_file_path: "era-compiler-tests/solidity/complex/array_one_element/test.json"
```

After doing some digging, I discovered that we were attempting to compute the function selector from the function name alone and without making use of the function arguments types.

I corrected that to align more with the matter-labs-tester: now we obtain the function selector from the ABI by function name. It looks like the matter-labs team do not account for function overloads, and therefore we didn't account for them either. It seems like they enforce that there will never be function overloads in tests (at least in the functions that gets called from the tests). 

I then faced the following error after correcting the way that we compute the function selector:

```
  2025-07-13T14:38:54.180925Z ERROR revive_dt_core::driver: Failed to construct legacy transaction: Unsupported type: uint256[1]
    at crates/core/src/driver/mod.rs:145 on main ThreadId(1)
    in revive_dt_core::driver::Executing case with case: "first", case_idx: 0
    in retester::Running driver with metadata_file_path: "era-compiler-tests/solidity/complex/array_one_element/test.json"

  2025-07-13T14:38:54.180949Z ERROR revive_dt_core::driver: Leader execution failed for Main: Unsupported type: uint256[1]
    at crates/core/src/driver/mod.rs:476 on main ThreadId(1)
    in revive_dt_core::driver::Executing case with case: "first", case_idx: 0
    in retester::Running driver with metadata_file_path: "era-compiler-tests/solidity/complex/array_one_element/test.json"
```

Digging deeper, it looked like our implementation for argument encoding different from the implementation of matter-labs where we were trying to support more types than they support. Additionally, we attempt to decode the arguments based on the ABI of the method whereas they decode the arguments without the ABI context at all. In this case, I think that it's also best that we align with their implementation since they author the test suite and therefore it's better that our parser aligns with theirs. Therefore, I changed the implementation of `Input -> Calldata` to not rely on the ABI and to have the same parsing logic as them. 

These two changes have fixed the issues that I've been seeing, and I think that I finally got my first test case to work 🎉!