### PR TITLE
Increase geth instantiate timeout from 2s to 5s

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -54,7 +54,7 @@ pub struct Arguments {
     pub geth: PathBuf,
 
     /// The maximum time in milliseconds to wait for geth to start.
-    #[arg(long = "geth-start-timeout", default_value = "2000")]
+    #[arg(long = "geth-start-timeout", default_value = "5000")]
     pub geth_start_timeout: u64,
 
     /// The test network chain ID.


### PR DESCRIPTION
Just another super small thing: I consistently ran into `Error: node failed to spawn: Timeout in starting geth`. Increasing the wait timeout to 5s seems to reliably avoid this for me.