### PR TITLE
Allow the corpus to point to a single file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 license = "MIT/Apache-2.0"
 edition = "2024"
 repository = "https://github.com/paritytech/revive-differential-testing.git"
-rust-version = "1.85.0"
+rust-version = "1.88.0"
 
 [workspace.dependencies]
 revive-dt-common = { version = "0.1.0", path = "crates/common" }


### PR DESCRIPTION
Just a wee rearranging of the recursion in`collect_metadata` to allow the corpus to point to a single test file, which I am finding useful to be able to debug and fix one test at a time :)

