### PR TITLE
Added basic console reporting

### DIFF
--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -78,7 +78,6 @@ fn init_cli() -> anyhow::Result<Arguments> {
         .with_thread_names(true)
         .with_env_filter(EnvFilter::from_default_env())
         .with_ansi(false)
-        .with_writer(std::io::stderr)
         .pretty()
         .finish();
     tracing::subscriber::set_global_default(subscriber)?;
@@ -188,7 +187,7 @@ where
                         .any(|value| value.is_some_and(|value| !value));
 
                     if !contains_failures {
-                        println!(
+                        eprintln!(
                             "{}Succeeded:{} {} - {:?}",
                             GREEN,
                             RESET,
@@ -196,7 +195,7 @@ where
                             solc_mode
                         )
                     } else {
-                        println!(
+                        eprintln!(
                             "{}Failed:{} {} - {:?}",
                             RED,
                             RESET,
@@ -214,7 +213,7 @@ where
                     case_status.sort_by(|a, b| a.0.cmp(&b.0));
                     for (_, case_name, case_status) in case_status.into_iter() {
                         if case_status {
-                            println!(
+                            eprintln!(
                                 "{GREEN}  Case Succeeded:{RESET} {}",
                                 case_name
                                     .as_ref()
@@ -222,7 +221,7 @@ where
                                     .unwrap_or("Unnamed case")
                             )
                         } else {
-                            println!(
+                            eprintln!(
                                 "{RED}  Case Failed:{RESET} {}",
                                 case_name
                                     .as_ref()
@@ -231,7 +230,7 @@ where
                             )
                         };
                     }
-                    println!();
+                    eprintln!();
 
                     entries_to_delete.push((metadata_file_path.clone(), solc_mode.clone()));
                 }


### PR DESCRIPTION
## Summary

This PR adds some basic console reporting functionality to the tool allowing us to more easily see which metadata files succeeded and failed and allowing us to see which specific test cases within these metadata files succeeded failed.

## Description

This PR adds some very basic reporting functionality to the tool that allows us to get a live report in the console of which cases succeeded and failed which allows us to get feedback faster on the test case runs.

This is implemented as a second async task that runs alongside the driver task. The driver writes to a shared map the result of the cases and the reporting tool takes that and prints it if it needs to be printed.

With this change we now print all of the logs from the program to stderr instead of stdout so that the print statements in the program do not interfere with the logs.

<img width="2672" height="1527" alt="image" src="https://github.com/user-attachments/assets/4dace169-ca53-41b2-aa40-b41d5f60229c" />
