### PR TITLE
Use SolidityLang for solc downloads

### DIFF
--- a/crates/compiler/src/solc.rs
+++ b/crates/compiler/src/solc.rs
@@ -238,4 +238,25 @@ mod test {
             Version::new(0, 7, 6)
         )
     }
+
+    #[tokio::test]
+    async fn compiler_version_can_be_obtained1() {
+        // Arrange
+        let args = Arguments::default();
+        println!("Getting compiler path");
+        let path = Solc::get_compiler_executable(&args, Version::new(0, 4, 21))
+            .await
+            .unwrap();
+        println!("Got compiler path");
+        let compiler = Solc::new(path);
+
+        // Act
+        let version = compiler.version();
+
+        // Assert
+        assert_eq!(
+            version.expect("Failed to get version"),
+            Version::new(0, 4, 21)
+        )
+    }
 }

--- a/crates/solc-binaries/src/cache.rs
+++ b/crates/solc-binaries/src/cache.rs
@@ -11,14 +11,14 @@ use std::{
 
 use tokio::sync::Mutex;
 
-use crate::download::GHDownloader;
+use crate::download::SolcDownloader;
 
 pub const SOLC_CACHE_DIRECTORY: &str = "solc";
 pub(crate) static SOLC_CACHER: LazyLock<Mutex<HashSet<PathBuf>>> = LazyLock::new(Default::default);
 
 pub(crate) async fn get_or_download(
     working_directory: &Path,
-    downloader: &GHDownloader,
+    downloader: &SolcDownloader,
 ) -> anyhow::Result<PathBuf> {
     let target_directory = working_directory
         .join(SOLC_CACHE_DIRECTORY)
@@ -38,7 +38,7 @@ pub(crate) async fn get_or_download(
     Ok(target_file)
 }
 
-async fn download_to_file(path: &Path, downloader: &GHDownloader) -> anyhow::Result<()> {
+async fn download_to_file(path: &Path, downloader: &SolcDownloader) -> anyhow::Result<()> {
     tracing::info!("caching file: {}", path.display());
 
     let Ok(file) = File::create_new(path) else {

--- a/crates/solc-binaries/src/lib.rs
+++ b/crates/solc-binaries/src/lib.rs
@@ -6,7 +6,7 @@
 use std::path::{Path, PathBuf};
 
 use cache::get_or_download;
-use download::GHDownloader;
+use download::SolcDownloader;
 
 use revive_dt_common::types::VersionOrRequirement;
 
@@ -25,13 +25,13 @@ pub async fn download_solc(
     wasm: bool,
 ) -> anyhow::Result<PathBuf> {
     let downloader = if wasm {
-        GHDownloader::wasm(version).await
+        SolcDownloader::wasm(version).await
     } else if cfg!(target_os = "linux") {
-        GHDownloader::linux(version).await
+        SolcDownloader::linux(version).await
     } else if cfg!(target_os = "macos") {
-        GHDownloader::macosx(version).await
+        SolcDownloader::macosx(version).await
     } else if cfg!(target_os = "windows") {
-        GHDownloader::windows(version).await
+        SolcDownloader::windows(version).await
     } else {
         unimplemented!()
     }?;


### PR DESCRIPTION
## Summary

This PR switches from using github for downloading solc to using SolidityLang for downloading solc.

## Description

This PR switches from using Github to download the solc binaries to using SolidityLang.

This was done since we found that some releases do not exist in the github downloads and we need to obtain them from other sources and SolidityLang is the official source that we can get these binaries from.
