### PR TITLE
Make metadata serializable

### DIFF
--- a/crates/format/src/case.rs
+++ b/crates/format/src/case.rs
@@ -1,4 +1,4 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use revive_dt_common::macros::define_wrapper_type;
 
@@ -7,7 +7,7 @@ use crate::{
     mode::Mode,
 };
 
-#[derive(Debug, Default, Deserialize, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct Case {
     pub name: Option<String>,
     pub comment: Option<String>,

--- a/crates/format/src/input.rs
+++ b/crates/format/src/input.rs
@@ -17,7 +17,7 @@ use revive_dt_common::macros::define_wrapper_type;
 use crate::traits::ResolverApi;
 use crate::{metadata::ContractInstance, traits::ResolutionContext};
 
-#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, Eq, PartialEq)]
 pub struct Input {
     #[serde(default = "Input::default_caller")]
     pub caller: Address,
@@ -33,7 +33,7 @@ pub struct Input {
     pub variable_assignments: Option<VariableAssignments>,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(untagged)]
 pub enum Expected {
     Calldata(Calldata),
@@ -41,7 +41,7 @@ pub enum Expected {
     ExpectedMany(Vec<ExpectedOutput>),
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, Eq, PartialEq)]
 pub struct ExpectedOutput {
     pub compiler_version: Option<VersionReq>,
     pub return_data: Option<Calldata>,
@@ -50,7 +50,7 @@ pub struct ExpectedOutput {
     pub exception: bool,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, Eq, PartialEq)]
 pub struct Event {
     pub address: Option<String>,
     pub topics: Vec<String>,
@@ -108,7 +108,7 @@ pub struct Event {
 /// [`Single`]: Calldata::Single
 /// [`Compound`]: Calldata::Compound
 /// [reverse polish notation]: https://en.wikipedia.org/wiki/Reverse_Polish_notation
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(untagged)]
 pub enum Calldata {
     Single(Bytes),
@@ -142,7 +142,7 @@ enum Operation {
 }
 
 /// Specify how the contract is called.
-#[derive(Debug, Default, Deserialize, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub enum Method {
     /// Initiate a deploy transaction, calling contracts constructor.
     ///
@@ -167,7 +167,7 @@ define_wrapper_type!(
     pub struct EtherValue(U256);
 );
 
-#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, Eq, PartialEq)]
 pub struct VariableAssignments {
     /// A vector of the variable names to assign to the return data.
     ///

--- a/crates/format/src/metadata.rs
+++ b/crates/format/src/metadata.rs
@@ -43,12 +43,11 @@ impl Deref for MetadataFile {
     }
 }
 
-#[derive(Debug, Default, Deserialize, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct Metadata {
     pub targets: Option<Vec<String>>,
     pub cases: Vec<Case>,
     pub contracts: Option<BTreeMap<ContractInstance, ContractPathAndIdent>>,
-    // TODO: Convert into wrapper types for clarity.
     pub libraries: Option<BTreeMap<PathBuf, BTreeMap<ContractIdent, ContractInstance>>>,
     pub ignore: Option<bool>,
     pub modes: Option<Vec<Mode>>,

--- a/crates/format/src/mode.rs
+++ b/crates/format/src/mode.rs
@@ -16,6 +16,7 @@ pub struct SolcMode {
     pub solc_version: Option<semver::VersionReq>,
     solc_optimize: Option<bool>,
     pub llvm_optimizer_settings: Vec<String>,
+    mode_string: String,
 }
 
 impl SolcMode {
@@ -29,7 +30,10 @@ impl SolcMode {
     /// - A solc `SemVer version requirement` string
     /// - One or more `-OX` where X is a supposed to be an LLVM opt mode
     pub fn parse_from_mode_string(mode_string: &str) -> Option<Self> {
-        let mut result = Self::default();
+        let mut result = Self {
+            mode_string: mode_string.to_string(),
+            ..Default::default()
+        };
 
         let mut parts = mode_string.trim().split(" ");
 
@@ -102,5 +106,18 @@ impl<'de> Deserialize<'de> for Mode {
         }
 
         Ok(Self::Unknown(mode_string))
+    }
+}
+
+impl Serialize for Mode {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let string = match self {
+            Mode::Solidity(solc_mode) => &solc_mode.mode_string,
+            Mode::Unknown(string) => string,
+        };
+        string.serialize(serializer)
     }
 }


### PR DESCRIPTION
## Summary

This PR closes #127 where we needed to make the metadata format serializable in order to do the semantic tests translation.
