### PR TITLE
Implement storage empty assertion

### DIFF
--- a/assets/test_metadata.json
+++ b/assets/test_metadata.json
@@ -13,6 +13,14 @@
                     "expected_balance": "1233"
                 },
                 {
+                    "address": "0xdeadbeef00000000000000000000000000000042",
+                    "is_storage_empty": true
+                },
+                {
+                    "address": "0xdeadbeef00000000000000000000000000000042",
+                    "is_storage_empty": false
+                },
+                {
                     "instance": "WBTC_1",
                     "method": "#deployer",
                     "calldata": [

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -451,6 +451,7 @@ where
             .filter_map(|step| match step {
                 Step::FunctionCall(input) => Some(input.caller),
                 Step::BalanceAssertion(..) => None,
+                Step::StorageEmptyAssertion(..) => None,
             })
             .next()
             .unwrap_or(Input::default_caller());

--- a/crates/format/src/input.rs
+++ b/crates/format/src/input.rs
@@ -28,6 +28,8 @@ pub enum Step {
     FunctionCall(Box<Input>),
     /// A step for performing a balance assertion on some account or contract.
     BalanceAssertion(Box<BalanceAssertion>),
+    /// A step for asserting that the storage of some contract or account is empty.
+    StorageEmptyAssertion(Box<StorageEmptyAssertion>),
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Eq, PartialEq)]
@@ -58,6 +60,20 @@ pub struct BalanceAssertion {
 
     /// The amount of balance to assert that the account or contract has.
     pub expected_balance: U256,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, Eq, PartialEq)]
+pub struct StorageEmptyAssertion {
+    /// The address that the balance assertion should be done on.
+    ///
+    /// This is a string which will be resolved into an address when being processed. Therefore,
+    /// this could be a normal hex address, a variable such as `Test.address`, or perhaps even a
+    /// full on variable like `$VARIABLE:Uniswap`. It follows the same resolution rules that are
+    /// followed in the calldata.
+    pub address: String,
+
+    /// A boolean of whether the storage of the address is empty or not.
+    pub is_storage_empty: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]

--- a/crates/node-interaction/src/lib.rs
+++ b/crates/node-interaction/src/lib.rs
@@ -1,8 +1,8 @@
 //! This crate implements all node interactions.
 
-use alloy::primitives::{Address, U256};
+use alloy::primitives::{Address, StorageKey, U256};
 use alloy::rpc::types::trace::geth::{DiffMode, GethDebugTracingOptions, GethTrace};
-use alloy::rpc::types::{TransactionReceipt, TransactionRequest};
+use alloy::rpc::types::{EIP1186AccountProofResponse, TransactionReceipt, TransactionRequest};
 use anyhow::Result;
 
 /// An interface for all interactions with Ethereum compatible nodes.
@@ -25,4 +25,11 @@ pub trait EthereumNode {
 
     /// Returns the balance of the provided [`Address`] back.
     fn balance_of(&self, address: Address) -> impl Future<Output = Result<U256>>;
+
+    /// Returns the latest storage proof of the provided [`Address`]
+    fn latest_state_proof(
+        &self,
+        address: Address,
+        keys: Vec<StorageKey>,
+    ) -> impl Future<Output = Result<EIP1186AccountProofResponse>>;
 }

--- a/crates/node/src/geth.rs
+++ b/crates/node/src/geth.rs
@@ -17,14 +17,16 @@ use alloy::{
     eips::BlockNumberOrTag,
     genesis::{Genesis, GenesisAccount},
     network::{Ethereum, EthereumWallet, NetworkWallet},
-    primitives::{Address, BlockHash, BlockNumber, BlockTimestamp, FixedBytes, TxHash, U256},
+    primitives::{
+        Address, BlockHash, BlockNumber, BlockTimestamp, FixedBytes, StorageKey, TxHash, U256,
+    },
     providers::{
         Provider, ProviderBuilder,
         ext::DebugApi,
         fillers::{CachedNonceManager, ChainIdFiller, FillProvider, NonceFiller, TxFiller},
     },
     rpc::types::{
-        TransactionReceipt, TransactionRequest,
+        EIP1186AccountProofResponse, TransactionReceipt, TransactionRequest,
         trace::geth::{DiffMode, GethDebugTracingOptions, PreStateConfig, PreStateFrame},
     },
     signers::local::PrivateKeySigner,
@@ -377,6 +379,20 @@ impl EthereumNode for GethNode {
         self.provider()
             .await?
             .get_balance(address)
+            .await
+            .map_err(Into::into)
+    }
+
+    #[tracing::instrument(skip_all, fields(geth_node_id = self.id))]
+    async fn latest_state_proof(
+        &self,
+        address: Address,
+        keys: Vec<StorageKey>,
+    ) -> anyhow::Result<EIP1186AccountProofResponse> {
+        self.provider()
+            .await?
+            .get_proof(address, keys)
+            .latest()
             .await
             .map_err(Into::into)
     }

--- a/crates/node/src/kitchensink.rs
+++ b/crates/node/src/kitchensink.rs
@@ -17,7 +17,7 @@ use alloy::{
     },
     primitives::{
         Address, B64, B256, BlockHash, BlockNumber, BlockTimestamp, Bloom, Bytes, FixedBytes,
-        TxHash, U256,
+        StorageKey, TxHash, U256,
     },
     providers::{
         Provider, ProviderBuilder,
@@ -25,7 +25,7 @@ use alloy::{
         fillers::{CachedNonceManager, ChainIdFiller, FillProvider, NonceFiller, TxFiller},
     },
     rpc::types::{
-        TransactionReceipt,
+        EIP1186AccountProofResponse, TransactionReceipt,
         eth::{Block, Header, Transaction},
         trace::geth::{DiffMode, GethDebugTracingOptions, PreStateConfig, PreStateFrame},
     },
@@ -434,6 +434,20 @@ impl EthereumNode for KitchensinkNode {
         self.provider()
             .await?
             .get_balance(address)
+            .await
+            .map_err(Into::into)
+    }
+
+    #[tracing::instrument(skip_all, fields(kitchensink_node_id = self.id))]
+    async fn latest_state_proof(
+        &self,
+        address: Address,
+        keys: Vec<StorageKey>,
+    ) -> anyhow::Result<EIP1186AccountProofResponse> {
+        self.provider()
+            .await?
+            .get_proof(address, keys)
+            .latest()
             .await
             .map_err(Into::into)
     }


### PR DESCRIPTION
## Summary

Implemented storage is empty assertions which are required for the solidity semantic tests. This closes issue #129
