### PR TITLE
Split reporter and case runner

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -96,9 +96,13 @@ pub struct Arguments {
     #[arg(long, default_value = "1")]
     pub number_of_nodes: usize,
 
-    /// Determines the amount of threads that will will be used.
-    #[arg(long, default_value = "12")]
-    pub number_of_threads: usize,
+    /// Determines the amount of tokio worker threads that will will be used. Defaults to the number of CPU cores.
+    #[arg(long)]
+    pub number_of_threads: Option<usize>,
+
+    /// Determines the amount of concurrent tasks that will be spawned to run tests. Defaults to 10 x the number of nodes.
+    #[arg(long)]
+    pub number_concurrent_tasks: Option<usize>,
 
     /// Extract problems back to the test corpus.
     #[arg(short, long = "extract-problems")]


### PR DESCRIPTION
- Split the test runner and test reporter, using channel (unbounded since we aren't concerned about buildup here) to send messages from the former to the latter.
    - On my PR, I found that the runner would reliably hang after running tests. Using a channel here instead of loop + waiting simplifies the logic and ensures that when the channel tx's are dropped (ie no more tests), everything gracefully ends.
- Put a limit on max concurrent tasks when runnign tests to avoid too many open files (allow this to be configured by the user)
- Use default when number_of_threads isn't given (which is number of available CPUs). 