### PR TITLE
Add compiler directives

### DIFF
--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -55,6 +55,7 @@ pub struct CompilerInput {
     pub base_path: Option<PathBuf>,
     pub sources: HashMap<PathBuf, String>,
     pub libraries: HashMap<PathBuf, HashMap<String, Address>>,
+    pub revert_string_handling: Option<RevertString>,
 }
 
 /// The generic compilation output configuration.
@@ -91,6 +92,7 @@ where
                 base_path: Default::default(),
                 sources: Default::default(),
                 libraries: Default::default(),
+                revert_string_handling: Default::default(),
             },
             additional_options: T::Options::default(),
         }
@@ -142,6 +144,14 @@ where
         self
     }
 
+    pub fn with_revert_string_handling(
+        mut self,
+        revert_string_handling: impl Into<Option<RevertString>>,
+    ) -> Self {
+        self.input.revert_string_handling = revert_string_handling.into();
+        self
+    }
+
     pub fn with_additional_options(mut self, options: impl Into<T::Options>) -> Self {
         self.additional_options = options.into();
         self
@@ -159,4 +169,16 @@ where
     pub fn input(&self) -> CompilerInput {
         self.input.clone()
     }
+}
+
+/// Defines how the compiler should handle revert strings.
+#[derive(
+    Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize,
+)]
+pub enum RevertString {
+    #[default]
+    Default,
+    Debug,
+    Strip,
+    VerboseDebug,
 }

--- a/crates/compiler/src/revive_resolc.rs
+++ b/crates/compiler/src/revive_resolc.rs
@@ -47,6 +47,9 @@ impl SolidityCompiler for Resolc {
             base_path,
             sources,
             libraries,
+            // TODO: this is currently not being handled since there is no way to pass it into
+            // resolc. So, we need to go back to this later once it's supported.
+            revert_string_handling: _,
         }: CompilerInput,
         additional_options: Self::Options,
     ) -> anyhow::Result<CompilerOutput> {

--- a/crates/compiler/src/solc.rs
+++ b/crates/compiler/src/solc.rs
@@ -42,6 +42,7 @@ impl SolidityCompiler for Solc {
             base_path,
             sources,
             libraries,
+            revert_string_handling,
         }: CompilerInput,
         _: Self::Options,
     ) -> anyhow::Result<CompilerOutput> {
@@ -87,6 +88,15 @@ impl SolidityCompiler for Solc {
                         })
                         .collect(),
                 },
+                debug: revert_string_handling.map(|revert_string_handling| DebuggingSettings {
+                    revert_strings: match revert_string_handling {
+                        crate::RevertString::Default => Some(RevertStrings::Default),
+                        crate::RevertString::Debug => Some(RevertStrings::Debug),
+                        crate::RevertString::Strip => Some(RevertStrings::Strip),
+                        crate::RevertString::VerboseDebug => Some(RevertStrings::VerboseDebug),
+                    },
+                    debug_info: Default::default(),
+                }),
                 ..Default::default()
             },
         };

--- a/crates/format/src/metadata.rs
+++ b/crates/format/src/metadata.rs
@@ -75,6 +75,12 @@ pub struct Metadata {
     /// be run of the evm version of the nodes match the evm version specified here.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub required_evm_version: Option<EvmVersionRequirement>,
+
+    /// A set of compilation directives that will be passed to the compiler whenever the contracts for
+    /// the test are being compiled. Note that this differs from the [`Mode`]s in that a [`Mode`] is
+    /// just a filter for when a test can run whereas this is an instruction to the compiler.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub compiler_directives: Option<CompilationDirectives>,
 }
 
 impl Metadata {
@@ -488,6 +494,31 @@ impl From<EvmVersionRequirement> for String {
     fn from(value: EvmVersionRequirement) -> Self {
         value.to_string()
     }
+}
+
+/// A set of compilation directives that will be passed to the compiler whenever the contracts for
+/// the test are being compiled. Note that this differs from the [`Mode`]s in that a [`Mode`] is
+/// just a filter for when a test can run whereas this is an instruction to the compiler.
+/// Defines how the compiler should handle revert strings.
+#[derive(
+    Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize,
+)]
+pub struct CompilationDirectives {
+    /// Defines how the revert strings should be handled.
+    pub revert_string_handling: Option<RevertString>,
+}
+
+/// Defines how the compiler should handle revert strings.
+#[derive(
+    Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize,
+)]
+#[serde(rename_all = "camelCase")]
+pub enum RevertString {
+    #[default]
+    Default,
+    Debug,
+    Strip,
+    VerboseDebug,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Add compiler directives to the metadata format.

## Description

We need a way to instruct the compiler to compile certain contracts in the test suite in a certain way. This isn't quite the same as the solc-modes since the framework will attempt to execute the test on all of the solc-modes that match the modes in the metadata file, but compiler directives are always used and always honored by the framework regardless of what mode the tool is running in.
