### PR TITLE
Add a cached fs abstraction

### DIFF
--- a/crates/common/src/fs/cached_file_system.rs
+++ b/crates/common/src/fs/cached_file_system.rs
@@ -1,0 +1,38 @@
+//! Implements a cached file system that allows for files to be read once into memory and then when
+//! they're requested to be read again they will be returned from the cache.
+
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::{Arc, LazyLock},
+};
+
+use anyhow::Result;
+use tokio::sync::RwLock;
+
+#[allow(clippy::type_complexity)]
+static CACHE: LazyLock<Arc<RwLock<HashMap<PathBuf, Vec<u8>>>>> = LazyLock::new(Default::default);
+
+pub struct CachedFileSystem;
+
+impl CachedFileSystem {
+    pub async fn read(path: impl AsRef<Path>) -> Result<Vec<u8>> {
+        let cache_read_lock = CACHE.read().await;
+        match cache_read_lock.get(path.as_ref()) {
+            Some(entry) => Ok(entry.clone()),
+            None => {
+                drop(cache_read_lock);
+
+                let content = std::fs::read(&path)?;
+                let mut cache_write_lock = CACHE.write().await;
+                cache_write_lock.insert(path.as_ref().to_path_buf(), content.clone());
+                Ok(content)
+            }
+        }
+    }
+
+    pub async fn read_to_string(path: impl AsRef<Path>) -> Result<String> {
+        let content = Self::read(path).await?;
+        String::from_utf8(content).map_err(Into::into)
+    }
+}

--- a/crates/common/src/fs/mod.rs
+++ b/crates/common/src/fs/mod.rs
@@ -1,3 +1,5 @@
+mod cached_file_system;
 mod clear_dir;
 
+pub use cached_file_system::*;
 pub use clear_dir::*;

--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -5,7 +5,6 @@
 
 use std::{
     collections::HashMap,
-    fs::read_to_string,
     hash::Hash,
     path::{Path, PathBuf},
 };
@@ -16,7 +15,7 @@ use semver::Version;
 use serde::{Deserialize, Serialize};
 
 use revive_common::EVMVersion;
-use revive_dt_common::types::VersionOrRequirement;
+use revive_dt_common::{fs::CachedFileSystem, types::VersionOrRequirement};
 use revive_dt_config::Arguments;
 
 pub mod revive_js;
@@ -123,10 +122,11 @@ where
         self
     }
 
-    pub fn with_source(mut self, path: impl AsRef<Path>) -> anyhow::Result<Self> {
-        self.input
-            .sources
-            .insert(path.as_ref().to_path_buf(), read_to_string(path.as_ref())?);
+    pub async fn with_source(mut self, path: impl AsRef<Path>) -> anyhow::Result<Self> {
+        self.input.sources.insert(
+            path.as_ref().to_path_buf(),
+            CachedFileSystem::read_to_string(path.as_ref()).await?,
+        );
         Ok(self)
     }
 


### PR DESCRIPTION
## Summary

This PR adds a cached file system abstraction which allows for static files to be read once and then get cached to the memory. The hope is that this will remove the issues we're seeing related to:

```
2025-08-14T06:59:11.166030Z ERROR retester: Execution failed, error: Bad file descriptor (os error 9)
    at crates/core/src/main.rs:342 on main ThreadId(1)
    in retester::Running driver with metadata_file_path: fixtures/solidity/translated_semantic_tests/viaYul/storage/dirty_storage_static_array/test.json, case_idx: 0, solc_mode: Mode { pipeline: Y, optimize_setting: M0, version: None }
```
