### PR TITLE
Implement GH actions for compiling, exporting and comparing hashes

### DIFF
--- a/.github/actions/compare-bytecode-hashes/action.yml
+++ b/.github/actions/compare-bytecode-hashes/action.yml
@@ -21,10 +21,6 @@ inputs:
     description: "The name for the uploaded comparison result artifact."
     required: true
 
-env:
-  # The hash file name expected to exist in the downloaded artifacts.
-  HASH_FILE_NAME: hashes.json
-
 runs:
   using: "composite"
   steps:
@@ -65,9 +61,9 @@ runs:
       shell: bash
       run: |
         shopt -s nullglob
-        HASH_FILES=(./all-hashes/*/${{ env.HASH_FILE_NAME }})
+        HASH_FILES=(./all-hashes/*/hashes.json)
         if [[ ${#HASH_FILES[@]} -eq 0 ]]; then
-          echo "::error::No hash files found matching ./all-hashes/*/${{ env.HASH_FILE_NAME }}"
+          echo "::error::No hash files found matching ./all-hashes/*/hashes.json"
           exit 1
         fi
 

--- a/.github/actions/compare-bytecode-hashes/action.yml
+++ b/.github/actions/compare-bytecode-hashes/action.yml
@@ -1,0 +1,106 @@
+name: "Compare Bytecode Hashes"
+description: "Compares bytecode hashes using report-processor, and uploads the comparison result."
+
+inputs:
+  revive-differential-tests-path:
+    description: "The path to an existing checkout of revive-differential-tests. If empty, revive-differential-tests-ref is checked out."
+    required: false
+    default: ""
+  revive-differential-tests-ref:
+    description: "The branch, tag, or SHA to checkout if revive-differential-tests-path is not provided."
+    required: false
+    default: "main"
+  hash-artifact-names:
+    description: "Comma-separated hash artifact names to download and compare (e.g. 'hashes-linux, hashes-macos, hashes-windows')."
+    required: true
+  modes:
+    description: "Comma-separated compiler modes to compare (e.g. 'Y M0 S+, Y M3 S+, Y Mz S+'). If empty, the union of all modes found in the files will be compared."
+    required: false
+    default: ""
+  upload-artifact-name:
+    description: "The name for the uploaded comparison result artifact."
+    required: true
+
+env:
+  # The hash file name expected to exist in the downloaded artifacts.
+  HASH_FILE_NAME: hashes.json
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout revive-differential-tests
+      if: ${{ inputs.revive-differential-tests-path == '' }}
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      with:
+        repository: paritytech/revive-differential-tests
+        ref: ${{ inputs.revive-differential-tests-ref }}
+        path: revive-differential-tests
+
+    - name: Resolve the repo path
+      id: repo
+      shell: bash
+      run: echo "path=${{ inputs.revive-differential-tests-path || 'revive-differential-tests' }}" >> "$GITHUB_OUTPUT"
+
+    - name: Install report-processor
+      shell: bash
+      run: cargo install --locked --path "${{ steps.repo.outputs.path }}/crates/report-processor"
+
+    - name: Trim hash artifact names
+      id: artifacts
+      shell: bash
+      run: |
+        # Strip spaces around commas.
+        CLEANED=$(echo "${{ inputs.hash-artifact-names }}" | sed 's/ *, */,/g')
+        echo "names=$CLEANED" >> "$GITHUB_OUTPUT"
+
+    - name: Download hash artifacts
+      uses: actions/download-artifact@v7
+      with:
+        pattern: "{${{ steps.artifacts.outputs.names }}}"
+        path: ./all-hashes
+        merge-multiple: false
+
+    - name: Compare hashes
+      id: compare
+      shell: bash
+      run: |
+        shopt -s nullglob
+        HASH_FILES=(./all-hashes/*/${{ env.HASH_FILE_NAME }})
+        if [[ ${#HASH_FILES[@]} -eq 0 ]]; then
+          echo "::error::No hash files found matching ./all-hashes/*/${{ env.HASH_FILE_NAME }}"
+          exit 1
+        fi
+
+        HASH_ARGS=()
+        for file in "${HASH_FILES[@]}"; do
+          HASH_ARGS+=(--hash-path "$file")
+        done
+
+        MODE_ARGS=()
+        if [[ -n "${{ inputs.modes }}" ]]; then
+          # Strip spaces around commas.
+          CLEANED_MODES=$(echo "${{ inputs.modes }}" | sed 's/ *, */,/g')
+          IFS=',' read -ra MODES <<< "$CLEANED_MODES"
+          for mode in "${MODES[@]}"; do
+            MODE_ARGS+=(--mode "$mode")
+          done
+        fi
+
+        # Echo the result path before running the report-processor in order for
+        # the result to be uploaded when comparison fails due to mismatches found.
+        RESULT_PATH="./hash-comparison.json"
+        echo "result-path=$RESULT_PATH" >> "$GITHUB_OUTPUT"
+
+        report-processor compare-hashes \
+          "${HASH_ARGS[@]}" \
+          "${MODE_ARGS[@]}" \
+          --output-path "$RESULT_PATH"
+
+    - name: Upload comparison result
+      if: always()
+      uses: actions/upload-artifact@v6
+      with:
+        name: ${{ inputs.upload-artifact-name }}
+        path: ${{ steps.compare.outputs.result-path }}
+        retention-days: 3
+        if-no-files-found: error

--- a/.github/actions/compare-bytecode-hashes/action.yml
+++ b/.github/actions/compare-bytecode-hashes/action.yml
@@ -26,7 +26,7 @@ runs:
   steps:
     - name: Checkout revive-differential-tests
       if: ${{ inputs.revive-differential-tests-path == '' }}
-      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      uses: actions/checkout@v6
       with:
         repository: paritytech/revive-differential-tests
         ref: ${{ inputs.revive-differential-tests-ref }}

--- a/.github/actions/compile-contracts/action.yml
+++ b/.github/actions/compile-contracts/action.yml
@@ -38,7 +38,7 @@ runs:
   steps:
     - name: Checkout revive-differential-tests
       if: ${{ inputs.revive-differential-tests-path == '' }}
-      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      uses: actions/checkout@v6
       with:
         repository: paritytech/revive-differential-tests
         ref: ${{ inputs.revive-differential-tests-ref }}

--- a/.github/actions/compile-contracts/action.yml
+++ b/.github/actions/compile-contracts/action.yml
@@ -1,5 +1,5 @@
 name: "Compile Contracts"
-description: "Builds and runs revive-differential-tests's retester to compile contracts, and uploads the compilation report."
+description: "Compiles contracts using retester, and uploads the compilation report."
 
 inputs:
   revive-differential-tests-path:
@@ -18,7 +18,7 @@ inputs:
     required: false
     default: ""
   modes:
-    description: "Comma-separated compiler modes (e.g. 'Y M0 S+, Y M3 S+, Y Mz S+'). If empty, retester's default is used."
+    description: "Comma-separated compiler modes to compile with (e.g. 'Y M0 S+, Y M3 S+, Y Mz S+'). If empty, retester's default is used."
     required: false
     default: ""
   upload-artifact-name:
@@ -60,7 +60,7 @@ runs:
 
     - name: Create workdir for retester
       shell: bash
-      run: mkdir -p ${{ env.WORK_DIR }}
+      run: mkdir -p "${{ env.WORK_DIR }}"
 
     - name: Compile contracts
       id: compile
@@ -83,8 +83,7 @@ runs:
           --compile "${{ steps.repo.outputs.path }}/resolc-compiler-tests/fixtures/solidity" \
           "${MODE_ARGS[@]}" \
           --resolc.path "${{ inputs.resolc-path }}" \
-          --resolc.heap-size 528000 \
-          --resolc.stack-size 128000 \
+          --resolc.heap-size 500000 \
           ${SOLC_VERSION:+--solc.version "$SOLC_VERSION"} \
           --report.file-name "$REPORT_FILE_NAME" \
           --working-directory "${{ env.WORK_DIR }}" \
@@ -92,12 +91,19 @@ runs:
           --concurrency.number-of-concurrent-tasks 100 \
           || true
 
-        echo "report-path=${{ env.WORK_DIR }}/$REPORT_FILE_NAME" >> "$GITHUB_OUTPUT"
+        REPORT_PATH="${{ env.WORK_DIR }}/$REPORT_FILE_NAME"
+        if [[ ! -f "$REPORT_PATH" ]]; then
+          echo "::error::Compilation report was not generated at $REPORT_PATH"
+          exit 1
+        fi
+
+        echo "report-path=$REPORT_PATH" >> "$GITHUB_OUTPUT"
         echo "contracts-source-prefix=$(realpath "${{ steps.repo.outputs.path }}")" >> "$GITHUB_OUTPUT"
 
     - name: Upload the compilation report
-      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+      uses: actions/upload-artifact@v6
       with:
         name: ${{ inputs.upload-artifact-name }}
         path: ${{ steps.compile.outputs.report-path }}
         retention-days: 3
+        if-no-files-found: error

--- a/.github/actions/compile-contracts/action.yml
+++ b/.github/actions/compile-contracts/action.yml
@@ -50,6 +50,17 @@ runs:
       shell: bash
       run: echo "path=${{ inputs.revive-differential-tests-path || 'revive-differential-tests' }}" >> "$GITHUB_OUTPUT"
 
+    - name: Install dependencies
+      shell: bash
+      run: |
+        if [[ "$RUNNER_OS" == "Linux" ]]; then
+          sudo apt-get update && sudo apt-get install -y protobuf-compiler
+        elif [[ "$RUNNER_OS" == "macOS" ]]; then
+          brew install protobuf
+        elif [[ "$RUNNER_OS" == "Windows" ]]; then
+          choco install protoc -y
+        fi
+
     - name: Install retester
       shell: bash
       run: cargo install --locked --path "${{ steps.repo.outputs.path }}/crates/core"

--- a/.github/actions/compile-contracts/action.yml
+++ b/.github/actions/compile-contracts/action.yml
@@ -118,6 +118,7 @@ runs:
           ${SOLC_VERSION:+--solc.version "$SOLC_VERSION"} \
           --report.file-name "$REPORT_FILE_NAME" \
           --report.include-compiler-output \
+          --report.include-compiler-input \
           --working-directory ./workdir \
           --concurrency.number-of-threads 10 \
           --concurrency.number-of-concurrent-tasks 100 \

--- a/.github/actions/compile-contracts/action.yml
+++ b/.github/actions/compile-contracts/action.yml
@@ -100,6 +100,7 @@ runs:
           --resolc.heap-size 500000 \
           ${SOLC_VERSION:+--solc.version "$SOLC_VERSION"} \
           --report.file-name "$REPORT_FILE_NAME" \
+          --report.include-compiler-output \
           --working-directory ./workdir \
           --concurrency.number-of-threads 10 \
           --concurrency.number-of-concurrent-tasks 100 \

--- a/.github/actions/compile-contracts/action.yml
+++ b/.github/actions/compile-contracts/action.yml
@@ -30,7 +30,7 @@ outputs:
     description: "The path to the generated compilation report JSON file."
     value: ${{ steps.compile.outputs.report-path }}
   contracts-source-prefix:
-    description: "The absolute path prefix common to all source paths in the compilation report. (Can be used as the `remove-prefix` input when exporting bytecode hashes.)"
+    description: "The path prefix common to all source paths in the compilation report. (Can be used as the `remove-prefix` input when exporting bytecode hashes.)"
     value: ${{ steps.compile.outputs.contracts-source-prefix }}
 
 runs:
@@ -94,7 +94,7 @@ runs:
         fi
 
         echo "report-path=$REPORT_PATH" >> "$GITHUB_OUTPUT"
-        echo "contracts-source-prefix=$(realpath "${{ steps.repo.outputs.path }}")" >> "$GITHUB_OUTPUT"
+        echo "contracts-source-prefix=${{ steps.repo.outputs.path }}/resolc-compiler-tests" >> "$GITHUB_OUTPUT"
 
     - name: Upload the compilation report
       uses: actions/upload-artifact@v6

--- a/.github/actions/compile-contracts/action.yml
+++ b/.github/actions/compile-contracts/action.yml
@@ -18,10 +18,10 @@ inputs:
     required: false
     default: ""
   modes:
-    description: "Comma-separated compiler modes (e.g. 'Y M0 S+,Y M3 S+,Y Mz S+'). If empty, retester's default is used."
+    description: "Comma-separated compiler modes (e.g. 'Y M0 S+, Y M3 S+, Y Mz S+'). If empty, retester's default is used."
     required: false
     default: ""
-  report-artifact-name:
+  upload-artifact-name:
     description: "The name for the uploaded compilation report artifact."
     required: true
 
@@ -29,6 +29,13 @@ outputs:
   report-path:
     description: "The path to the generated compilation report JSON file."
     value: ${{ steps.compile.outputs.report-path }}
+  contracts-source-prefix:
+    description: "The absolute path prefix common to all source paths in the compilation report. (Can be used as the `remove-prefix` input when exporting bytecode hashes.)"
+    value: ${{ steps.compile.outputs.contracts-source-prefix }}
+
+env:
+  # Working directory for the retester (used internally for writing the report).
+  WORK_DIR: ./workdir
 
 runs:
   using: "composite"
@@ -45,7 +52,7 @@ runs:
     - name: Resolve the repo path
       id: repo
       shell: bash
-      run: echo "path=$(realpath ${{ inputs.revive-differential-tests-path || 'revive-differential-tests' }})" >> "$GITHUB_OUTPUT"
+      run: echo "path=${{ inputs.revive-differential-tests-path || 'revive-differential-tests' }}" >> "$GITHUB_OUTPUT"
 
     - name: Install retester
       shell: bash
@@ -53,14 +60,12 @@ runs:
 
     - name: Create workdir for retester
       shell: bash
-      run: mkdir -p workdir
+      run: mkdir -p ${{ env.WORK_DIR }}
 
     - name: Compile contracts
       id: compile
       shell: bash
       run: |
-        REPO_PATH="${{ steps.repo.outputs.path }}"
-        WORKDIR="./workdir"
         REPORT_FILE_NAME="compilation-report.json"
         SOLC_VERSION="${{ inputs.solc-version }}"
 
@@ -75,22 +80,24 @@ runs:
         fi
 
         retester compile \
-          --compile "$REPO_PATH/resolc-compiler-tests/fixtures/solidity" \
+          --compile "${{ steps.repo.outputs.path }}/resolc-compiler-tests/fixtures/solidity" \
           "${MODE_ARGS[@]}" \
           --resolc.path "${{ inputs.resolc-path }}" \
           --resolc.heap-size 528000 \
           --resolc.stack-size 128000 \
           ${SOLC_VERSION:+--solc.version "$SOLC_VERSION"} \
           --report.file-name "$REPORT_FILE_NAME" \
-          --working-directory "$WORKDIR" \
+          --working-directory "${{ env.WORK_DIR }}" \
           --concurrency.number-of-threads 10 \
           --concurrency.number-of-concurrent-tasks 100 \
           || true
 
-        echo "report-path=$WORKDIR/$REPORT_FILE_NAME" >> "$GITHUB_OUTPUT"
+        echo "report-path=${{ env.WORK_DIR }}/$REPORT_FILE_NAME" >> "$GITHUB_OUTPUT"
+        echo "contracts-source-prefix=$(realpath "${{ steps.repo.outputs.path }}")" >> "$GITHUB_OUTPUT"
 
     - name: Upload the compilation report
       uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
       with:
-        name: ${{ inputs.report-artifact-name }}
+        name: ${{ inputs.upload-artifact-name }}
         path: ${{ steps.compile.outputs.report-path }}
+        retention-days: 3

--- a/.github/actions/compile-contracts/action.yml
+++ b/.github/actions/compile-contracts/action.yml
@@ -50,7 +50,22 @@ runs:
       shell: bash
       run: echo "path=${{ inputs.revive-differential-tests-path || 'revive-differential-tests' }}" >> "$GITHUB_OUTPUT"
 
+    - name: Resolve the retester cache key
+      id: retester-cache-key
+      shell: bash
+      run: |
+        sha=$(git -C "${{ steps.repo.outputs.path }}" rev-parse HEAD)
+        echo "key=retester-${{ runner.os }}-${sha}" >> "$GITHUB_OUTPUT"
+
+    - name: Cache retester
+      id: retester-cache
+      uses: actions/cache@v5
+      with:
+        path: ~/.cargo/bin/retester${{ runner.os == 'Windows' && '.exe' || '' }}
+        key: ${{ steps.retester-cache-key.outputs.key }}
+
     - name: Set up Rust toolchain
+      if: ${{ steps.retester-cache.outputs.cache-hit != 'true' }}
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         target: wasm32-unknown-unknown
@@ -58,6 +73,7 @@ runs:
         rustflags: ""
 
     - name: Install dependencies
+      if: ${{ steps.retester-cache.outputs.cache-hit != 'true' }}
       shell: bash
       run: |
         if [[ "$RUNNER_OS" == "Linux" ]]; then
@@ -69,6 +85,7 @@ runs:
         fi
 
     - name: Install retester
+      if: ${{ steps.retester-cache.outputs.cache-hit != 'true' }}
       shell: bash
       run: cargo install --locked --path "${{ steps.repo.outputs.path }}/crates/core"
 

--- a/.github/actions/compile-contracts/action.yml
+++ b/.github/actions/compile-contracts/action.yml
@@ -1,5 +1,5 @@
 name: "Compile Contracts"
-description: "Builds and runs revive-differential-tests's retester compilations from this repo and uploads the compilation report."
+description: "Builds and runs revive-differential-tests's retester to compile contracts, and uploads the compilation report."
 
 inputs:
   revive-differential-tests-path:
@@ -23,8 +23,12 @@ inputs:
     default: ""
   report-artifact-name:
     description: "The name for the uploaded compilation report artifact."
-    required: false
-    default: "compilation-report"
+    required: true
+
+outputs:
+  report-path:
+    description: "The path to the generated compilation report JSON file."
+    value: ${{ steps.compile.outputs.report-path }}
 
 runs:
   using: "composite"
@@ -41,7 +45,7 @@ runs:
     - name: Resolve the repo path
       id: repo
       shell: bash
-      run: echo "path=${{ inputs.revive-differential-tests-path || 'revive-differential-tests' }}" >> "$GITHUB_OUTPUT"
+      run: echo "path=$(realpath ${{ inputs.revive-differential-tests-path || 'revive-differential-tests' }})" >> "$GITHUB_OUTPUT"
 
     - name: Install retester
       shell: bash
@@ -52,9 +56,12 @@ runs:
       run: mkdir -p workdir
 
     - name: Compile contracts
+      id: compile
       shell: bash
       run: |
         REPO_PATH="${{ steps.repo.outputs.path }}"
+        WORKDIR="./workdir"
+        REPORT_FILE_NAME="compilation-report.json"
         SOLC_VERSION="${{ inputs.solc-version }}"
 
         MODE_ARGS=()
@@ -74,14 +81,16 @@ runs:
           --resolc.heap-size 528000 \
           --resolc.stack-size 128000 \
           ${SOLC_VERSION:+--solc.version "$SOLC_VERSION"} \
-          --report.file-name compilation-report.json \
-          --working-directory ./workdir \
+          --report.file-name "$REPORT_FILE_NAME" \
+          --working-directory "$WORKDIR" \
           --concurrency.number-of-threads 10 \
           --concurrency.number-of-concurrent-tasks 100 \
           || true
+
+        echo "report-path=$WORKDIR/$REPORT_FILE_NAME" >> "$GITHUB_OUTPUT"
 
     - name: Upload the compilation report
       uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
       with:
         name: ${{ inputs.report-artifact-name }}
-        path: ./workdir/compilation-report.json
+        path: ${{ steps.compile.outputs.report-path }}

--- a/.github/actions/compile-contracts/action.yml
+++ b/.github/actions/compile-contracts/action.yml
@@ -1,0 +1,87 @@
+name: "Compile Contracts"
+description: "Builds and runs revive-differential-tests's retester compilations from this repo and uploads the compilation report."
+
+inputs:
+  revive-differential-tests-path:
+    description: "The path to an existing checkout of revive-differential-tests. If empty, revive-differential-tests-ref is checked out."
+    required: false
+    default: ""
+  revive-differential-tests-ref:
+    description: "The branch, tag, or SHA to checkout if revive-differential-tests-path is not provided."
+    required: false
+    default: "main"
+  resolc-path:
+    description: "The path to the resolc binary."
+    required: true
+  solc-version:
+    description: "The solc version to use. If empty, retester's default is used."
+    required: false
+    default: ""
+  modes:
+    description: "Comma-separated compiler modes (e.g. 'Y M0 S+,Y M3 S+,Y Mz S+'). If empty, retester's default is used."
+    required: false
+    default: ""
+  report-artifact-name:
+    description: "The name for the uploaded compilation report artifact."
+    required: false
+    default: "compilation-report"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout revive-differential-tests
+      if: ${{ inputs.revive-differential-tests-path == '' }}
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      with:
+        repository: paritytech/revive-differential-tests
+        ref: ${{ inputs.revive-differential-tests-ref }}
+        path: revive-differential-tests
+        submodules: recursive
+
+    - name: Resolve the repo path
+      id: repo
+      shell: bash
+      run: echo "path=${{ inputs.revive-differential-tests-path || 'revive-differential-tests' }}" >> "$GITHUB_OUTPUT"
+
+    - name: Install retester
+      shell: bash
+      run: cargo install --locked --path "${{ steps.repo.outputs.path }}/crates/core"
+
+    - name: Create workdir for retester
+      shell: bash
+      run: mkdir -p workdir
+
+    - name: Compile contracts
+      shell: bash
+      run: |
+        REPO_PATH="${{ steps.repo.outputs.path }}"
+        SOLC_VERSION="${{ inputs.solc-version }}"
+
+        MODE_ARGS=()
+        if [[ -n "${{ inputs.modes }}" ]]; then
+          # Strip spaces around commas.
+          CLEANED_MODES=$(echo "${{ inputs.modes }}" | sed 's/ *, */,/g')
+          IFS=',' read -ra MODES <<< "$CLEANED_MODES"
+          for mode in "${MODES[@]}"; do
+            MODE_ARGS+=(--mode "$mode")
+          done
+        fi
+
+        retester compile \
+          --compile "$REPO_PATH/resolc-compiler-tests/fixtures/solidity" \
+          "${MODE_ARGS[@]}" \
+          --resolc.path "${{ inputs.resolc-path }}" \
+          --resolc.heap-size 528000 \
+          --resolc.stack-size 128000 \
+          ${SOLC_VERSION:+--solc.version "$SOLC_VERSION"} \
+          --report.file-name compilation-report.json \
+          --working-directory ./workdir \
+          --concurrency.number-of-threads 10 \
+          --concurrency.number-of-concurrent-tasks 100 \
+          || true
+
+    - name: Upload the compilation report
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+      with:
+        name: ${{ inputs.report-artifact-name }}
+        path: ./workdir/compilation-report.json

--- a/.github/actions/compile-contracts/action.yml
+++ b/.github/actions/compile-contracts/action.yml
@@ -50,15 +50,22 @@ runs:
       shell: bash
       run: echo "path=${{ inputs.revive-differential-tests-path || 'revive-differential-tests' }}" >> "$GITHUB_OUTPUT"
 
+    - name: Set up Rust toolchain
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        target: wasm32-unknown-unknown
+        components: rust-src
+        rustflags: ""
+
     - name: Install dependencies
       shell: bash
       run: |
         if [[ "$RUNNER_OS" == "Linux" ]]; then
-          sudo apt-get update && sudo apt-get install -y protobuf-compiler
+          sudo apt-get update && sudo apt-get install -y build-essential pkg-config libssl-dev protobuf-compiler clang libclang-dev
         elif [[ "$RUNNER_OS" == "macOS" ]]; then
           brew install protobuf
         elif [[ "$RUNNER_OS" == "Windows" ]]; then
-          choco install protoc -y
+          choco install -y protoc llvm
         fi
 
     - name: Install retester

--- a/.github/actions/compile-contracts/action.yml
+++ b/.github/actions/compile-contracts/action.yml
@@ -33,10 +33,6 @@ outputs:
     description: "The absolute path prefix common to all source paths in the compilation report. (Can be used as the `remove-prefix` input when exporting bytecode hashes.)"
     value: ${{ steps.compile.outputs.contracts-source-prefix }}
 
-env:
-  # Working directory for the retester (used internally for writing the report).
-  WORK_DIR: ./workdir
-
 runs:
   using: "composite"
   steps:
@@ -58,9 +54,9 @@ runs:
       shell: bash
       run: cargo install --locked --path "${{ steps.repo.outputs.path }}/crates/core"
 
-    - name: Create workdir for retester
+    - name: Create working directory for retester
       shell: bash
-      run: mkdir -p "${{ env.WORK_DIR }}"
+      run: mkdir -p ./workdir
 
     - name: Compile contracts
       id: compile
@@ -86,12 +82,12 @@ runs:
           --resolc.heap-size 500000 \
           ${SOLC_VERSION:+--solc.version "$SOLC_VERSION"} \
           --report.file-name "$REPORT_FILE_NAME" \
-          --working-directory "${{ env.WORK_DIR }}" \
+          --working-directory ./workdir \
           --concurrency.number-of-threads 10 \
           --concurrency.number-of-concurrent-tasks 100 \
           || true
 
-        REPORT_PATH="${{ env.WORK_DIR }}/$REPORT_FILE_NAME"
+        REPORT_PATH="./workdir/$REPORT_FILE_NAME"
         if [[ ! -f "$REPORT_PATH" ]]; then
           echo "::error::Compilation report was not generated at $REPORT_PATH"
           exit 1

--- a/.github/actions/export-bytecode-hashes/action.yml
+++ b/.github/actions/export-bytecode-hashes/action.yml
@@ -1,5 +1,5 @@
 name: "Export Bytecode Hashes"
-description: "Builds and runs revive-differential-tests's report-processor to extract bytecode hashes from a retester report, and uploads the hash file."
+description: "Extracts bytecode hashes from a retester report using report-processor, and uploads the hash file."
 
 inputs:
   revive-differential-tests-path:
@@ -14,7 +14,7 @@ inputs:
     description: "The path to the retester report JSON file."
     required: true
   remove-prefix:
-    description: "The absolute path prefix to strip from source paths in the report for cross-platform normalization. This must match the runner that produced the report."
+    description: "The absolute path prefix to strip from source paths in the report for cross-platform normalization. Must be a path from the runner that produced the report."
     required: true
   platform-label:
     description: "The platform label indicating which platform the hashes were generated on (e.g. 'linux', 'macos')."
@@ -24,8 +24,8 @@ inputs:
     required: true
 
 env:
-  # Output path for the exported hashes file.
-  HASH_OUTPUT_PATH: ./hashes.json
+  # The file name for the exported hash file.
+  HASH_FILE_NAME: hashes.json
 
 runs:
   using: "composite"
@@ -52,13 +52,14 @@ runs:
       run: |
         report-processor export-hashes \
           --report-path "${{ inputs.report-path }}" \
-          --output-path "${{ env.HASH_OUTPUT_PATH }}" \
+          --output-path "./${{ env.HASH_FILE_NAME }}" \
           --remove-prefix "${{ inputs.remove-prefix }}" \
           --platform-label "${{ inputs.platform-label }}"
 
     - name: Upload hashes
-      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+      uses: actions/upload-artifact@v6
       with:
         name: ${{ inputs.upload-artifact-name }}
-        path: ${{ env.HASH_OUTPUT_PATH }}
+        path: ./${{ env.HASH_FILE_NAME }}
         retention-days: 3
+        if-no-files-found: error

--- a/.github/actions/export-bytecode-hashes/action.yml
+++ b/.github/actions/export-bytecode-hashes/action.yml
@@ -1,0 +1,64 @@
+name: "Export Bytecode Hashes"
+description: "Builds and runs revive-differential-tests's report-processor to extract bytecode hashes from a retester report, and uploads the hash file."
+
+inputs:
+  revive-differential-tests-path:
+    description: "The path to an existing checkout of revive-differential-tests. If empty, revive-differential-tests-ref is checked out."
+    required: false
+    default: ""
+  revive-differential-tests-ref:
+    description: "The branch, tag, or SHA to checkout if revive-differential-tests-path is not provided."
+    required: false
+    default: "main"
+  report-path:
+    description: "The path to the retester report JSON file."
+    required: true
+  remove-prefix:
+    description: "The absolute path prefix to strip from source paths in the report for cross-platform normalization. This must match the runner that produced the report."
+    required: true
+  platform-label:
+    description: "The platform label indicating which platform the hashes were generated on (e.g. 'linux', 'macos')."
+    required: true
+  upload-artifact-name:
+    description: "The name for the uploaded hash file artifact."
+    required: true
+
+env:
+  # Output path for the exported hashes file.
+  HASH_OUTPUT_PATH: ./hashes.json
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout revive-differential-tests
+      if: ${{ inputs.revive-differential-tests-path == '' }}
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      with:
+        repository: paritytech/revive-differential-tests
+        ref: ${{ inputs.revive-differential-tests-ref }}
+        path: revive-differential-tests
+
+    - name: Resolve the repo path
+      id: repo
+      shell: bash
+      run: echo "path=${{ inputs.revive-differential-tests-path || 'revive-differential-tests' }}" >> "$GITHUB_OUTPUT"
+
+    - name: Install report-processor
+      shell: bash
+      run: cargo install --locked --path "${{ steps.repo.outputs.path }}/crates/report-processor"
+
+    - name: Export hashes
+      shell: bash
+      run: |
+        report-processor export-hashes \
+          --report-path "${{ inputs.report-path }}" \
+          --output-path "${{ env.HASH_OUTPUT_PATH }}" \
+          --remove-prefix "${{ inputs.remove-prefix }}" \
+          --platform-label "${{ inputs.platform-label }}"
+
+    - name: Upload hashes
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+      with:
+        name: ${{ inputs.upload-artifact-name }}
+        path: ${{ env.HASH_OUTPUT_PATH }}
+        retention-days: 3

--- a/.github/actions/export-bytecode-hashes/action.yml
+++ b/.github/actions/export-bytecode-hashes/action.yml
@@ -17,15 +17,11 @@ inputs:
     description: "The absolute path prefix to strip from source paths in the report for cross-platform normalization. Must be a path from the runner that produced the report."
     required: true
   platform-label:
-    description: "The platform label indicating which platform the hashes were generated on (e.g. 'linux', 'macos')."
+    description: "The platform label indicating which platform the hashes were generated on (e.g. 'linux', 'macos'). This is included in the exported file."
     required: true
   upload-artifact-name:
     description: "The name for the uploaded hash file artifact."
     required: true
-
-env:
-  # The file name for the exported hash file.
-  HASH_FILE_NAME: hashes.json
 
 runs:
   using: "composite"
@@ -52,7 +48,7 @@ runs:
       run: |
         report-processor export-hashes \
           --report-path "${{ inputs.report-path }}" \
-          --output-path "./${{ env.HASH_FILE_NAME }}" \
+          --output-path "./hashes.json" \
           --remove-prefix "${{ inputs.remove-prefix }}" \
           --platform-label "${{ inputs.platform-label }}"
 
@@ -60,6 +56,6 @@ runs:
       uses: actions/upload-artifact@v6
       with:
         name: ${{ inputs.upload-artifact-name }}
-        path: ./${{ env.HASH_FILE_NAME }}
+        path: ./hashes.json
         retention-days: 3
         if-no-files-found: error

--- a/.github/actions/export-bytecode-hashes/action.yml
+++ b/.github/actions/export-bytecode-hashes/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: "The path to the retester report JSON file."
     required: true
   remove-prefix:
-    description: "The absolute path prefix to strip from source paths in the report for cross-platform normalization. Must be a path from the runner that produced the report."
+    description: "The relative or absolute path prefix to strip from source paths in the report for cross-platform normalization. Must point to a directory on the runner that produced the report."
     required: true
   platform-label:
     description: "The platform label indicating which platform the hashes were generated on (e.g. 'linux', 'macos'). This is included in the exported file."

--- a/.github/actions/export-bytecode-hashes/action.yml
+++ b/.github/actions/export-bytecode-hashes/action.yml
@@ -28,7 +28,7 @@ runs:
   steps:
     - name: Checkout revive-differential-tests
       if: ${{ inputs.revive-differential-tests-path == '' }}
-      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      uses: actions/checkout@v6
       with:
         repository: paritytech/revive-differential-tests
         ref: ${{ inputs.revive-differential-tests-ref }}

--- a/.github/actions/run-differential-tests/action.yml
+++ b/.github/actions/run-differential-tests/action.yml
@@ -70,30 +70,55 @@ runs:
         ref: ${{ inputs['revive-differential-tests-ref'] }}
         path: revive-differential-tests
         submodules: recursive
+
     - name: Resolve the repo path
       id: repo
       shell: bash
       run: echo "path=${{ inputs.revive-differential-tests-path || 'revive-differential-tests' }}" >> "$GITHUB_OUTPUT"
+
     - name: Creating a workdir for retester
       shell: bash
       run: mkdir -p workdir
+
     - name: Downloading & Initializing the compilation caches
       shell: bash
       if: ${{ inputs['use-compilation-caches'] == true }}
       run: |
         curl -fL --retry 3 --retry-all-errors --connect-timeout 10 -o cache.tar.gz "https://github.com/paritytech/revive-differential-tests/releases/download/compilation-caches-v1.1/cache.tar.gz"
         tar -zxf cache.tar.gz -C ./workdir > /dev/null 2>&1
+
     - name: Building the dependencies from the Polkadot SDK
       shell: bash
       run: |
         ${{ inputs['cargo-command'] }} build --locked --profile release -p pallet-revive-eth-rpc -p revive-dev-node --manifest-path ${{ inputs['polkadot-sdk-path'] }}/Cargo.toml
         ${{ inputs['cargo-command'] }} build --locked --profile release --bin polkadot-omni-node --manifest-path ${{ inputs['polkadot-sdk-path'] }}/Cargo.toml
+
+    - name: Resolve the retester cache key
+      id: retester-cache-key
+      shell: bash
+      run: |
+        sha=$(git -C "${{ steps.repo.outputs.path }}" rev-parse HEAD)
+        echo "key=retester-${{ runner.os }}-${sha}" >> "$GITHUB_OUTPUT"
+
+    - name: Cache retester and report-processor
+      id: retester-cache
+      uses: actions/cache@v5
+      with:
+        path: |
+          ~/.cargo/bin/retester
+          ~/.cargo/bin/report-processor
+        key: ${{ steps.retester-cache-key.outputs.key }}
+
     - name: Installing retester
+      if: ${{ steps.retester-cache.outputs.cache-hit != 'true' }}
       shell: bash
       run: ${{ inputs['cargo-command'] }} install --locked --path "${{ steps.repo.outputs.path }}/crates/core"
+
     - name: Installing report-processor
+      if: ${{ steps.retester-cache.outputs.cache-hit != 'true' }}
       shell: bash
       run: ${{ inputs['cargo-command'] }} install --locked --path "${{ steps.repo.outputs.path }}/crates/report-processor"
+
     - name: Running the Differential Tests
       shell: bash
       run: |
@@ -131,19 +156,23 @@ runs:
           --resolc.heap-size 500000 \
           ${SOLC_VERSION:+--solc.version "$SOLC_VERSION"} \
           "${OMNI_ARGS[@]}" || true
+
     - name: Generate the expectation file
       shell: bash
       run: report-processor generate-expectations-file --report-path ./workdir/report.json --output-path ./workdir/expectations.json --remove-prefix "${{ steps.repo.outputs.path }}/resolc-compiler-tests" --include-status failed
+
     - name: Upload the Report to the CI
       uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
       with:
         name: ${{ inputs['platform'] }}-report.json
         path: ./workdir/report.json
+
     - name: Upload the Report to the CI
       uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
       with:
         name: ${{ inputs['platform'] }}.json
         path: ./workdir/expectations.json
+
     - name: Check Expectations
       shell: bash
       if: ${{ inputs['expectations-file-path'] != '' }}

--- a/.github/actions/run-differential-tests/action.yml
+++ b/.github/actions/run-differential-tests/action.yml
@@ -31,6 +31,7 @@ inputs:
     description: "The solc version to use. If empty, retester's default is used."
     required: false
     default: ""
+    type: string
   use-compilation-caches:
     description: "Controls if the compilation caches will be used for the test run or not."
     required: false
@@ -75,7 +76,7 @@ runs:
       run: echo "path=${{ inputs.revive-differential-tests-path || 'revive-differential-tests' }}" >> "$GITHUB_OUTPUT"
     - name: Creating a workdir for retester
       shell: bash
-      run: mkdir workdir
+      run: mkdir -p workdir
     - name: Downloading & Initializing the compilation caches
       shell: bash
       if: ${{ inputs['use-compilation-caches'] == true }}
@@ -116,17 +117,17 @@ runs:
           --test "${{ steps.repo.outputs.path }}/resolc-compiler-tests/fixtures/solidity/simple" \
           --test "${{ steps.repo.outputs.path }}/resolc-compiler-tests/fixtures/solidity/complex" \
           --test "${{ steps.repo.outputs.path }}/resolc-compiler-tests/fixtures/solidity/translated_semantic_tests" \
-          --platform ${{ inputs['platform'] }} \
+          --platform "${{ inputs['platform'] }}" \
           --report.file-name report.json \
           --concurrency.number-of-nodes 10 \
           --concurrency.number-of-threads 10 \
           --concurrency.number-of-concurrent-tasks 100 \
           --working-directory ./workdir \
           --revive-dev-node.consensus manual-seal-200 \
-          --revive-dev-node.path ${{ inputs['polkadot-sdk-path'] }}/target/release/revive-dev-node \
-          --eth-rpc.path ${{ inputs['polkadot-sdk-path'] }}/target/release/eth-rpc \
-          --polkadot-omni-node.path ${{ inputs['polkadot-sdk-path'] }}/target/release/polkadot-omni-node \
-          --resolc.path ${{ inputs['resolc-path'] }} \
+          --revive-dev-node.path "${{ inputs['polkadot-sdk-path'] }}/target/release/revive-dev-node" \
+          --eth-rpc.path "${{ inputs['polkadot-sdk-path'] }}/target/release/eth-rpc" \
+          --polkadot-omni-node.path "${{ inputs['polkadot-sdk-path'] }}/target/release/polkadot-omni-node" \
+          --resolc.path "${{ inputs['resolc-path'] }}" \
           --resolc.heap-size 500000 \
           ${SOLC_VERSION:+--solc.version "$SOLC_VERSION"} \
           "${OMNI_ARGS[@]}" || true

--- a/.github/actions/run-differential-tests/action.yml
+++ b/.github/actions/run-differential-tests/action.yml
@@ -27,6 +27,10 @@ inputs:
     description: "The path of the resolc compiler."
     required: true
     type: string
+  solc-version:
+    description: "The solc version to use. If empty, retester's default is used."
+    required: false
+    default: ""
   use-compilation-caches:
     description: "Controls if the compilation caches will be used for the test run or not."
     required: false
@@ -92,6 +96,8 @@ runs:
     - name: Running the Differential Tests
       shell: bash
       run: |
+        SOLC_VERSION="${{ inputs.solc-version }}"
+
         OMNI_ARGS=()
         if [[ -n "${{ inputs['polkadot-omnichain-node-parachain-id'] }}" ]]; then
           OMNI_ARGS+=(
@@ -122,6 +128,7 @@ runs:
           --polkadot-omni-node.path ${{ inputs['polkadot-sdk-path'] }}/target/release/polkadot-omni-node \
           --resolc.path ${{ inputs['resolc-path'] }} \
           --resolc.heap-size 500000 \
+          ${SOLC_VERSION:+--solc.version "$SOLC_VERSION"} \
           "${OMNI_ARGS[@]}" || true
     - name: Generate the expectation file
       shell: bash


### PR DESCRIPTION
## Summary

Adds GH actions usable by other repos' workflows.

Actions:
* Run `retester` in compile-only mode, which compiles contracts, hashes the bytecode, and generates a report
* Run `report-processor` to extract and export the bytecode hashes from a report generated by `retester`
* Run `report-processor` to compare the bytecode hashes in the exported hash files

**Example usage:**

```yml
jobs:
  compile-and-export-hashes:
    strategy:
      fail-fast: false
      matrix:
        include:
          # ..matrix of platforms..
    runs-on: ${{ matrix.runner }}
    steps:

      # ...

      - name: Compile Contracts
        id: compile
        uses: paritytech/revive-differential-tests/.github/actions/compile-contracts
        with:
          revive-differential-tests-ref: some-ref
          resolc-path: path/to/resolc/binary
          solc-version: "0.8.33"
          modes: "Y M0 S+, Y M3 S+, Y Mz S+"
          upload-artifact-name: compilation-report-${{ matrix.platform }}

      - name: Export Bytecode Hashes
        uses: paritytech/revive-differential-tests/.github/actions/export-bytecode-hashes
        with:
          revive-differential-tests-ref: some-ref
          report-path: ${{ steps.compile.outputs.report-path }}
          remove-prefix: ${{ steps.compile.outputs.contracts-source-prefix }}
          platform-label: ${{ matrix.platform }}
          upload-artifact-name: hashes-${{ matrix.platform }}

  compare-hashes:
    needs: [compile-and-export-hashes]
    runs-on: ubuntu-24.04
    steps:

      # ...

      - name: Compare Bytecode Hashes
        uses: paritytech/revive-differential-tests/.github/actions/compare-bytecode-hashes
        with:
          revive-differential-tests-ref: some-ref
          hash-artifact-names: "hashes-linux, hashes-macos, hashes-windows"
          modes: "Y M0 S+, Y M3 S+, Y Mz S+"
          upload-artifact-name: hash-comparison-result
```