### PR TITLE
Update docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ report-processor generate-expectations-file \
     --include-status failed
 ```
 
-## Supported Platforms
+### Supported Platforms
 
 | Platform CLI Name | Description |
 |-------------------|-------------|
@@ -98,6 +98,64 @@ report-processor generate-expectations-file \
 | `zombienet-revm-solc` | Zombienet REVM + Solc |
 | `polkadot-omni-node-polkavm-resolc` | Polkadot Omni Node + Resolc |
 | `polkadot-omni-node-revm-solc` | Polkadot Omni Node + Solc |
+
+## Running Compilations and Comparing Bytecode Hashes
+
+You can compile contracts using different resolc builds (e.g. for Linux, macOS, and Windows) without executing differential tests. The compilation modes to compile each contract with (e.g. `Y M3 S+`) are passed via `--mode` arguments.
+
+The bytecode hashes generated are included in the compilation report and can be exported and then compared in order to verify that the bytecode produced by each build is identical for the specified mode.
+
+### Compiling Contracts
+
+How to compile (for each platform/build):
+
+```bash
+retester compile \
+    --compile ./resolc-compiler-tests/fixtures/solidity/simple \
+    --compile ./resolc-compiler-tests/fixtures/solidity/complex \
+    --compile ./resolc-compiler-tests/fixtures/solidity/translated_semantic_tests \
+    --mode "Y M0 S+" \
+    --mode "Y M3 S+" \
+    --mode "Y Mz S+" \
+    --resolc.path /path/to/resolc \
+    --resolc.heap-size 500000 \
+    --solc.version "0.8.33" \
+    --report.file-name report-compile.json \
+    --report.include-compiler-input \
+    --report.include-compiler-output \
+    --working-directory ./workdir \
+    --concurrency.number-of-threads 10 \
+    --concurrency.number-of-concurrent-tasks 100 \
+    > logs-compile.log \
+    2> output-compile.log
+```
+
+### Exporting Bytecode Hashes
+
+How to export bytecode hashes (for each platform/build):
+
+```bash
+report-processor export-hashes \
+    --report-path ./workdir/report-compile.json \
+    --output-path ./exported-hashes/hashes-macos.json \
+    --remove-prefix ./resolc-compiler-tests \
+    --platform-label macos
+```
+
+### Comparing Bytecode Hashes
+
+How to compare bytecode hashes:
+
+```bash
+report-processor compare-hashes \
+    --hash-path ./exported-hashes/hashes-macos.json \
+    --hash-path ./exported-hashes/hashes-linux.json \
+    --hash-path ./exported-hashes/hashes-windows.json \
+    --mode "Y M0 S+" \
+    --mode "Y M3 S+" \
+    --mode "Y Mz S+" \
+    --output-path ./hash-comparison.json
+```
 
 ## Architecture
 
@@ -151,7 +209,7 @@ For tests that fail gas estimation (e.g., due to `consume_all_gas` behavior in r
 ## External Dependencies
 
 **Always required:**
-- Solc (Solidity compiler) - auto-downloaded but resolc needs it in PATH
+- Solc (Solidity compiler) - auto-downloaded
 
 **Platform-specific:**
 | Platform | Required Tools |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,46 +8,11 @@ Revive Differential Tests is a differential testing framework for Ethereum-compa
 
 The test corpus lives in a separate repository: [resolc-compiler-tests](https://github.com/paritytech/resolc-compiler-tests) and is included as a git submodule.
 
-## Build and Test Commands
+## CLI Usage
 
-```bash
-# Build release binary
-cargo build --release
+Run `retester --help` and `report-processor --help` for up-to-date CLI usage information.
 
-# Install retester and report-processor binaries
-cargo install --path crates/core
-cargo install --path crates/report-processor
-
-# Run unit tests
-cargo make test
-
-# Linting and formatting
-cargo make fmt-check      # Check formatting
-cargo make clippy         # Run clippy with --deny warnings
-cargo make machete        # Check for unused dependencies
-```
-
-## Running Differential Tests
-
-### Full Test Suite (PolkaVM with Resolc)
-
-This is how the polkadot-sdk CI runs tests:
-
-```bash
-retester test \
-    --test ./resolc-compiler-tests/fixtures/solidity/simple \
-    --test ./resolc-compiler-tests/fixtures/solidity/complex \
-    --test ./resolc-compiler-tests/fixtures/solidity/translated_semantic_tests \
-    -p revive-dev-node-polkavm-resolc \
-    --report.file-name report.json \
-    --concurrency.number-of-nodes 10 \
-    --concurrency.number-of-threads 10 \
-    --concurrency.number-of-concurrent-tasks 100 \
-    --working-directory ./workdir \
-    --revive-dev-node.consensus manual-seal-200 \
-    --resolc.heap-size 528000 \
-    --resolc.stack-size 128000
-```
+## Troubleshooting
 
 ### Important Resolc Parameters
 
@@ -57,172 +22,7 @@ retester test \
 | `--resolc.stack-size` | 131072 | Contract stack size in bytes. |
 | `--resolc.path` | (from PATH) | Path to resolc binary. |
 
-**Critical:** These are **compile-time** settings embedded in the PVM bytecode. Changing them requires clearing the compilation cache (see Troubleshooting).
-
-### Test Specifiers
-
-```bash
-# Run all tests in a directory
--t ./resolc-compiler-tests/fixtures/solidity/simple
-
-# Run specific test file
--t path/to/test.sol
-
-# Run specific case within a metadata file (case_idx is 0-indexed)
--t path/to/metadata.json::0
-
-# Run specific case with specific mode
--t path/to/metadata.json::0::Y\ M0
-```
-
-### Report Processing
-
-```bash
-# Generate expectations file from test report
-report-processor generate-expectations-file \
-    --report-path ./workdir/report.json \
-    --output-path expectations.json \
-    --remove-prefix ./resolc-compiler-tests \
-    --include-status failed
-```
-
-### Supported Platforms
-
-| Platform CLI Name | Description |
-|-------------------|-------------|
-| `geth-evm-solc` | Go-Ethereum reference EVM + Solc |
-| `lighthouse-geth-evm-solc` | Geth with Lighthouse consensus + Solc |
-| `revive-dev-node-polkavm-resolc` | Substrate PolkaVM + Resolc |
-| `revive-dev-node-revm-solc` | Substrate REVM + Solc |
-| `zombienet-polkavm-resolc` | Zombienet Substrate + Resolc |
-| `zombienet-revm-solc` | Zombienet REVM + Solc |
-| `polkadot-omni-node-polkavm-resolc` | Polkadot Omni Node + Resolc |
-| `polkadot-omni-node-revm-solc` | Polkadot Omni Node + Solc |
-
-## Running Compilations and Comparing Bytecode Hashes
-
-You can compile contracts using different resolc builds (e.g. for Linux, macOS, and Windows) without executing differential tests. The compilation modes to compile each contract with (e.g. `Y M3 S+`) are passed via `--mode` arguments.
-
-The bytecode hashes generated are included in the compilation report and can be exported and then compared in order to verify that the bytecode produced by each build is identical for the specified mode.
-
-### Compiling Contracts
-
-How to compile (for each platform/build):
-
-```bash
-retester compile \
-    --compile ./resolc-compiler-tests/fixtures/solidity/simple \
-    --compile ./resolc-compiler-tests/fixtures/solidity/complex \
-    --compile ./resolc-compiler-tests/fixtures/solidity/translated_semantic_tests \
-    --mode "Y M0 S+" \
-    --mode "Y M3 S+" \
-    --mode "Y Mz S+" \
-    --resolc.path /path/to/resolc \
-    --resolc.heap-size 500000 \
-    --solc.version "0.8.33" \
-    --report.file-name report-compile.json \
-    --report.include-compiler-input \
-    --report.include-compiler-output \
-    --working-directory ./workdir \
-    --concurrency.number-of-threads 10 \
-    --concurrency.number-of-concurrent-tasks 100 \
-    > logs-compile.log \
-    2> output-compile.log
-```
-
-### Exporting Bytecode Hashes
-
-How to export bytecode hashes (for each platform/build):
-
-```bash
-report-processor export-hashes \
-    --report-path ./workdir/report-compile.json \
-    --output-path ./exported-hashes/hashes-macos.json \
-    --remove-prefix ./resolc-compiler-tests \
-    --platform-label macos
-```
-
-### Comparing Bytecode Hashes
-
-How to compare bytecode hashes:
-
-```bash
-report-processor compare-hashes \
-    --hash-path ./exported-hashes/hashes-macos.json \
-    --hash-path ./exported-hashes/hashes-linux.json \
-    --hash-path ./exported-hashes/hashes-windows.json \
-    --mode "Y M0 S+" \
-    --mode "Y M3 S+" \
-    --mode "Y Mz S+" \
-    --output-path ./hash-comparison.json
-```
-
-## Architecture
-
-The project is a Rust workspace (edition 2024, MSRV 1.87.0) with crates in `/crates/`:
-
-- **core** (`retester` binary) - Main test runner and orchestrator
-- **config** - CLI argument parsing via Clap; defines `Context` enum (Test, Benchmark, ExportJsonSchema, ExportGenesis)
-- **format** - Declarative test definition format based on MatterLabs; includes `gas_overrides` support for platform-specific gas limits
-- **common** - Shared types including `PlatformIdentifier`, `ParsedTestSpecifier`, `Mode`, `ParsedMode`
-- **compiler** - Compilation abstraction for Solc and Resolc compilers
-  - `revive_resolc.rs`: Uses `SolcStandardJsonInputSettingsSelection::new_required_for_tests()` to request `evm.bytecode` output (required for resolc 0.6.0+)
-- **node** - Platform/node implementations in `src/node_implementations/`
-- **node-interaction** - Transaction submission, gas estimation via alloy, receipt waiting
-  - `fallback_gas_filler.rs`: Handles gas estimation for reverting transactions using debug traces
-- **report** - Test result aggregation and reporting (JSON format)
-- **report-processor** - Secondary binary for post-execution report analysis
-- **solc-binaries** - Solc compiler binary caching and downloads
-
-## Test Format
-
-Tests use the MatterLabs format with metadata either as JSON files or inline Solidity comments:
-
-```
-Corpus (directory)
-└── Metadata (JSON file or Solidity with inline comments)
-    └── Case (individual test)
-        ├── targets (optional): filter to specific platforms
-        ├── modes (optional): restrict to specific compiler modes (e.g., ["E-"] for EVM assembly only)
-        ├── gas_overrides (optional): platform-specific hardcoded gas limits
-        └── Steps
-            ├── Transaction steps with assertions
-            └── State assertions (balances, storage)
-```
-
-### Gas Overrides
-
-For tests that fail gas estimation (e.g., due to `consume_all_gas` behavior in resolc), use `gas_overrides`:
-
-```json
-{
-  "method": "test",
-  "calldata": ["0x100000000"],
-  "gas_overrides": {
-    "revive-dev-node-polkavm-resolc": {
-      "gas_limit": 10000000
-    }
-  }
-}
-```
-
-## External Dependencies
-
-**Always required:**
-- Solc (Solidity compiler) - auto-downloaded
-
-**Platform-specific:**
-| Platform | Required Tools |
-|----------|----------------|
-| `geth-evm-solc` | Geth |
-| `lighthouse-geth-evm-solc` | Geth, Kurtosis, Docker |
-| `revive-dev-node-*` | revive-dev-node, eth-rpc |
-| `zombienet-*` | Zombienet SDK binaries |
-| `polkadot-omni-node-*` | polkadot-omni-node, eth-rpc |
-
-**For PolkaVM platforms:** Resolc compiler
-
-## Troubleshooting
+**Critical:** These are **compile-time** settings embedded in the PVM bytecode. Changing them requires clearing the compilation cache (see [Clearing the Compilation Cache](#clearing-the-compilation-cache)).
 
 ### Clearing the Compilation Cache
 
@@ -243,9 +43,3 @@ rm -rf ./workdir
 4. **Tests failing after changing resolc parameters** - Clear the compilation cache (`rm -rf ./workdir`) to force recompilation.
 
 5. **Gas estimation failures for reverting transactions** - The test may need `gas_overrides` in the test metadata to specify a hardcoded gas limit.
-
-## Updating the Test Submodule
-
-```bash
-git submodule update --init --remote resolc-compiler-tests
-```

--- a/README.md
+++ b/README.md
@@ -42,13 +42,12 @@ This section describes the required dependencies that this framework requires to
 - Geth - When doing differential testing against the PVM we submit transactions to a Geth node and to Revive Dev Node to compare them.
 - Revive Dev Node - When doing differential testing against the PVM we submit transactions to a Geth node and to Revive Dev Node to compare them.
 - ETH-RPC - All communication with Revive Dev Node is done through the ETH RPC.
-- Solc - This is actually a transitive dependency, while this tool doesn't require solc as it downloads the versions that it requires, resolc requires that Solc is installed and available in the path.
 - Resolc - This is required to compile the contracts to PolkaVM bytecode.
 - Kurtosis - The Kurtosis CLI tool is required for the production Ethereum mainnet-like node configuration with Geth as the execution layer and lighthouse as the consensus layer. Kurtosis also requires docker to be installed since it runs everything inside of docker containers.
 
 All of the above need to be installed and available in the path in order for the tool to work.
 
-## Running The Tool
+## Running Differential Tests
 
 This tool is being updated quite frequently. Therefore, it's recommended that you don't install the tool and then run it, but rather that you run it from the root of the directory using `cargo run --release --bin retester`. The help command of the tool gives you all of the information you need to know about each of the options and flags that the tool offers.
 
@@ -118,3 +117,61 @@ RUST_LOG="info" retester test \
 ```
 
 </details>
+
+## Running Compilations and Comparing Bytecode Hashes
+
+You can compile contracts using different resolc builds (e.g. for Linux, macOS, and Windows) without executing differential tests. The compilation modes to compile each contract with (e.g. `Y M3 S+`) are passed via `--mode` arguments.
+
+The bytecode hashes generated are included in the compilation report and can be exported and then compared in order to verify that the bytecode produced by each build is identical for the specified mode.
+
+### Compiling Contracts
+
+How to compile (for each platform/build):
+
+```bash
+retester compile \
+    --compile ./resolc-compiler-tests/fixtures/solidity/simple \
+    --compile ./resolc-compiler-tests/fixtures/solidity/complex \
+    --compile ./resolc-compiler-tests/fixtures/solidity/translated_semantic_tests \
+    --mode "Y M0 S+" \
+    --mode "Y M3 S+" \
+    --mode "Y Mz S+" \
+    --resolc.path /path/to/resolc \
+    --resolc.heap-size 500000 \
+    --solc.version "0.8.33" \
+    --report.file-name report-compile.json \
+    --report.include-compiler-input \
+    --report.include-compiler-output \
+    --working-directory ./workdir \
+    --concurrency.number-of-threads 10 \
+    --concurrency.number-of-concurrent-tasks 100 \
+    > logs-compile.log \
+    2> output-compile.log
+```
+
+### Exporting Bytecode Hashes
+
+How to export bytecode hashes (for each platform/build):
+
+```bash
+report-processor export-hashes \
+    --report-path ./workdir/report-compile.json \
+    --output-path ./exported-hashes/hashes-macos.json \
+    --remove-prefix ./resolc-compiler-tests \
+    --platform-label macos
+```
+
+### Comparing Bytecode Hashes
+
+How to compare bytecode hashes:
+
+```bash
+report-processor compare-hashes \
+    --hash-path ./exported-hashes/hashes-macos.json \
+    --hash-path ./exported-hashes/hashes-linux.json \
+    --hash-path ./exported-hashes/hashes-windows.json \
+    --mode "Y M0 S+" \
+    --mode "Y M3 S+" \
+    --mode "Y Mz S+" \
+    --output-path ./hash-comparison.json
+```

--- a/README.md
+++ b/README.md
@@ -6,10 +6,16 @@
   </p>
 </div>
 
-This project compiles and executes declarative smart-contract tests against multiple platforms, then compares behavior (status, return data, events, and state diffs). Today it supports:
+This project compiles and executes declarative smart-contract tests against multiple platforms, then compares behavior (status, return data, events, and state diffs). Today it supports platforms such as:
 
 - Geth (EVM reference implementation)
 - Revive Dev Node (Substrate-based PolkaVM + `eth-rpc` proxy)
+
+To list all supported platforms, run:
+
+```bash
+retester test --help
+```
 
 Use it to:
 
@@ -32,7 +38,18 @@ All of the steps contained within each test case are either:
 
 All of the transactions submitted by the this tool to the test nodes follow a similar logic to what wallets do. We first use alloy to estimate the transaction fees, then we attach that to the transaction and submit it to the node and then await the transaction receipt.
 
-This repository contains none of the tests and only contains the testing framework or the test runner. The tests can be found in the [`resolc-compiler-tests`](https://github.com/paritytech/resolc-compiler-tests) repository which is a clone of [MatterLab's test suite](https://github.com/matter-labs/era-compiler-tests) with some modifications and adjustments made to suit our use case.
+## Test Fixtures and Cases
+
+This repository contains none of the tests and only contains the testing framework or the test runner.
+
+> [!NOTE]  
+> The tests can be found in the [`resolc-compiler-tests`](https://github.com/paritytech/resolc-compiler-tests) repository which is a clone of [MatterLab's test suite](https://github.com/matter-labs/era-compiler-tests) with some modifications and adjustments made to suit our use case.
+
+To update the test submodule, run:
+
+```bash
+git submodule update --init --remote resolc-compiler-tests
+```
 
 ## Requirements
 
@@ -47,12 +64,22 @@ This section describes the required dependencies that this framework requires to
 
 All of the above need to be installed and available in the path in order for the tool to work.
 
+## Build Commands
+
+```bash
+# Build release binary
+cargo build --release
+
+# Install retester and report-processor binaries
+cargo install --locked --path crates/core
+cargo install --locked --path crates/report-processor
+```
+
+See [Makefile.toml](./Makefile.toml) for available `cargo make` commands for testing, linting, etc.
+
 ## Running Differential Tests
 
 This tool is being updated quite frequently. Therefore, it's recommended that you don't install the tool and then run it, but rather that you run it from the root of the directory using `cargo run --release --bin retester`. The help command of the tool gives you all of the information you need to know about each of the options and flags that the tool offers.
-
-> [!NOTE]  
-> Note that the tests can be found in the [`resolc-compiler-tests`](https://github.com/paritytech/resolc-compiler-tests) repository.
 
 The simplest command to run this tool is the following:
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -223,7 +223,7 @@ mod context {
         ///   specifier with the exception that in this case the mode is specified and will be used
         ///   in the test.
         #[serde_as(as = "Vec<serde_with::DisplayFromStr>")]
-        #[arg(short = 't', long = "test", required = true)]
+        #[arg(short = 't', long = "test", required = true, verbatim_doc_comment)]
         pub test_specifiers: Vec<ParsedTestSpecifier>,
     }
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -111,7 +111,7 @@ mod context {
         pub corpus: CorpusExecutionConfiguration,
     }
 
-    /// Compiles contracts for pre-link compilations only without executing any tests.
+    /// Compiles contracts without executing any tests.
     #[subcommand]
     pub struct Compile {
         pub log: LogConfiguration,
@@ -227,11 +227,11 @@ mod context {
         pub test_specifiers: Vec<ParsedTestSpecifier>,
     }
 
-    /// A set of configuration parameters for the corpus files to use for the pre-link-only compilation.
+    /// A set of configuration parameters for the corpus files to use for the post-link-only compilation.
     #[serde_with::serde_as]
     #[configuration(key = "corpus")]
     pub struct CorpusCompilationConfiguration {
-        /// A list of compilation specifiers for the pre-link-only compilations that the tool should run.
+        /// A list of compilation specifiers for the post-link-only compilations that the tool should run.
         ///
         /// Compile specifiers follow the following format:
         ///

--- a/crates/core/src/compilations/entry_point.rs
+++ b/crates/core/src/compilations/entry_point.rs
@@ -1,4 +1,4 @@
-//! The main entry point into compiling in pre-link-only mode without any test execution.
+//! The main entry point into compiling in post-link-only mode without any test execution.
 
 use crate::internal_prelude::*;
 

--- a/crates/core/src/compilations/mod.rs
+++ b/crates/core/src/compilations/mod.rs
@@ -1,6 +1,6 @@
 //! This module contains all of the code responsible for performing compilations,
 //! including the driver implementation and the core logic that allows for contracts
-//! to be compiled in pre-link-only mode without any test execution.
+//! to be compiled in post-link-only mode without any test execution.
 
 mod driver;
 mod entry_point;

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -31,7 +31,7 @@ sp-core = { workspace = true }
 sp-runtime = { workspace = true }
 subxt = { workspace = true }
 # Zombienet uses `std::os::unix` which prevents compiling retester on Windows.
-# For running pre-link-only contract compilations on Windows, Zombienet is gated.
+# For running only contract compilations on Windows, Zombienet is gated.
 [target.'cfg(unix)'.dependencies]
 zombienet-sdk = { workspace = true }
 

--- a/crates/report-processor/src/export_hashes.rs
+++ b/crates/report-processor/src/export_hashes.rs
@@ -42,7 +42,7 @@ impl HashData {
     }
 }
 
-/// Extracts all bytecode hashes from pre-link compilations from a [`Report`].
+/// Extracts all bytecode hashes from post-link compilations from a [`Report`].
 pub fn extract_hashes(
     report: &Report,
     contracts_base_dir: &Path,

--- a/crates/report-processor/src/main.rs
+++ b/crates/report-processor/src/main.rs
@@ -443,7 +443,7 @@ pub enum Cli {
         output_path: PathBuf,
     },
 
-    /// Extracts and exports the bytecode hashes from pre-link compilations from a [`Report`].
+    /// Extracts and exports the bytecode hashes from post-link compilations from a [`Report`].
     ExportHashes {
         /// The path to the report's JSON file.
         #[clap(long = "report-path")]

--- a/crates/report-processor/src/main.rs
+++ b/crates/report-processor/src/main.rs
@@ -372,7 +372,7 @@ type Expectations<'a> = BTreeMap<TestSpecifier<'a>, Status>;
 #[derive(Clone, Debug, Parser)]
 #[command(name = "retester", term_width = 100)]
 pub enum Cli {
-    /// Generates an expectation file out of a given report.
+    /// Generates an expectation file (containing expected test execution statuses) out of a given report.
     GenerateExpectationsFile {
         /// The path of the report's JSON file to generate the expectation's file for.
         #[clap(long = "report-path")]

--- a/crates/report/src/reporter_event.rs
+++ b/crates/report/src/reporter_event.rs
@@ -16,7 +16,7 @@ pub enum ReporterEvent {
     },
 
     /// An event sent by the reporter once an entire metadata file and mode combination has
-    /// finished pre-link-only compilation.
+    /// finished post-link-only compilation.
     MetadataFileModeCombinationCompilationCompleted {
         metadata_file_path: MetadataFilePath,
         compilation_status: BTreeMap<Mode, CompilationStatus>,


### PR DESCRIPTION
## Summary

Updates docs such as CLAUDE.md and README.md to include `retester compile`, `report-processor export-hashes`, and `report-processor compare-hashes`. Removes some context from CLAUDE.md that has shown to be easily found and understood by Claude without it, and could diverge from the code base due to frequent updates.