### PR TITLE
Add the runner's arch to retester cache key in GH actions

### DIFF
--- a/.github/actions/compile-contracts/action.yml
+++ b/.github/actions/compile-contracts/action.yml
@@ -55,7 +55,7 @@ runs:
       shell: bash
       run: |
         sha=$(git -C "${{ steps.repo.outputs.path }}" rev-parse HEAD)
-        echo "key=retester-${{ runner.os }}-${sha}" >> "$GITHUB_OUTPUT"
+        echo "key=retester-${{ runner.os }}-${{ runner.arch }}-${sha}" >> "$GITHUB_OUTPUT"
 
     - name: Cache retester
       id: retester-cache

--- a/.github/actions/run-differential-tests/action.yml
+++ b/.github/actions/run-differential-tests/action.yml
@@ -98,7 +98,7 @@ runs:
       shell: bash
       run: |
         sha=$(git -C "${{ steps.repo.outputs.path }}" rev-parse HEAD)
-        echo "key=retester-${{ runner.os }}-${sha}" >> "$GITHUB_OUTPUT"
+        echo "key=retester-${{ runner.os }}-${{ runner.arch }}-${sha}" >> "$GITHUB_OUTPUT"
 
     - name: Cache retester and report-processor
       id: retester-cache


### PR DESCRIPTION
## Summary

Adds `runner.arch` to retester's cache key if called from e.g. both `macos-15` and `macos-15-intel` runners.