### PR TITLE
Add gas_overrides to benchmark driver and improve failing receipt logs

### DIFF
--- a/crates/core/src/differential_benchmarks/driver.rs
+++ b/crates/core/src/differential_benchmarks/driver.rs
@@ -475,12 +475,19 @@ where
                     .map(|receipt| receipt.transaction_hash)
             }
             Method::Fallback | Method::FunctionName(_) => {
-                let tx = step
+                let mut tx = step
                     .as_transaction(
                         self.platform_information.node,
                         self.default_resolution_context(),
                     )
                     .await?;
+
+                let gas_overrides = step
+                    .gas_overrides
+                    .get(&self.platform_information.platform.platform_identifier())
+                    .copied()
+                    .unwrap_or_default();
+                gas_overrides.apply_to::<Ethereum>(&mut tx);
 
                 let (tx_hash, receipt_future, inclusion_future) = self
                     .execute_transaction(tx.clone(), Some(step_path), Duration::from_secs(30 * 60))

--- a/crates/core/src/differential_benchmarks/watcher.rs
+++ b/crates/core/src/differential_benchmarks/watcher.rs
@@ -350,7 +350,10 @@ impl Watcher {
                 && !failing_receipts.is_empty()
             {
                 let watched_hashes: std::collections::HashSet<_> =
-                    transaction_registration_information.keys().copied().collect();
+                    transaction_registration_information
+                        .keys()
+                        .copied()
+                        .collect();
                 let (watched_failures, unwatched_failures): (Vec<_>, Vec<_>) = failing_receipts
                     .iter()
                     .partition(|r| watched_hashes.contains(&r.transaction_hash));

--- a/crates/core/src/differential_benchmarks/watcher.rs
+++ b/crates/core/src/differential_benchmarks/watcher.rs
@@ -349,8 +349,35 @@ impl Watcher {
                 .collect::<Vec<_>>()
                 && !failing_receipts.is_empty()
             {
+                let watched_hashes: std::collections::HashSet<_> =
+                    transaction_registration_information.keys().copied().collect();
+                let (watched_failures, unwatched_failures): (Vec<_>, Vec<_>) = failing_receipts
+                    .iter()
+                    .partition(|r| watched_hashes.contains(&r.transaction_hash));
+                error!(
+                    total_failing = failing_receipts.len(),
+                    watched_failing = watched_failures.len(),
+                    unwatched_failing = unwatched_failures.len(),
+                    "Encountered failing receipts"
+                );
+                for r in &failing_receipts {
+                    let is_watched = watched_hashes.contains(&r.transaction_hash);
+                    let step_path = transaction_registration_information
+                        .get(&r.transaction_hash)
+                        .map(|(sp, _)| sp.to_string());
+                    error!(
+                        tx_hash = %r.transaction_hash,
+                        block_number = ?r.block_number,
+                        from = %r.from,
+                        to = ?r.to,
+                        gas_used = %r.gas_used,
+                        step_path = ?step_path,
+                        is_watched,
+                        "Failing receipt"
+                    );
+                }
                 bail!(
-                    "Encountered failing receipts {failing_receipts:?}, len: {}",
+                    "Encountered failing receipts, len: {}",
                     failing_receipts.len()
                 );
             }


### PR DESCRIPTION
### Description
- Apply `gas_overrides` from test metadata in the benchmark driver, matching the existing behavior in the differential tests driver
- Improve error logging when benchmark transactions fail, adding per-receipt structured details

Both changes are motivated by the need to debug failing transactions during benchmarks, particularly out-of-gas (OOG) errors.
`gas_overrides` should be used with caution since they set a hardcoded `gas_limit` on the transaction, which affects how the block builder packs transactions. Overestimated gas limits reserve more block space than needed, potentially reducing measured throughput (TPS) and block density metrics.