### PR TITLE
Update cache key in run-differential-tests action

### DIFF
--- a/.github/actions/run-differential-tests/action.yml
+++ b/.github/actions/run-differential-tests/action.yml
@@ -98,7 +98,7 @@ runs:
       shell: bash
       run: |
         sha=$(git -C "${{ steps.repo.outputs.path }}" rev-parse HEAD)
-        echo "key=retester-and-report-processor-${{ runner.os }}-${{ runner.arch }}-${sha}" >> "$GITHUB_OUTPUT"
+        echo "key=retester-differential-tests-${{ runner.os }}-${{ runner.arch }}-${sha}" >> "$GITHUB_OUTPUT"
 
     - name: Cache retester and report-processor
       id: retester-cache

--- a/.github/actions/run-differential-tests/action.yml
+++ b/.github/actions/run-differential-tests/action.yml
@@ -98,7 +98,7 @@ runs:
       shell: bash
       run: |
         sha=$(git -C "${{ steps.repo.outputs.path }}" rev-parse HEAD)
-        echo "key=retester-${{ runner.os }}-${{ runner.arch }}-${sha}" >> "$GITHUB_OUTPUT"
+        echo "key=retester-and-report-processor-${{ runner.os }}-${{ runner.arch }}-${sha}" >> "$GITHUB_OUTPUT"
 
     - name: Cache retester and report-processor
       id: retester-cache


### PR DESCRIPTION
## Summary

Updates the cache key in the run-differential-tests action (caching retester and report-processor) to distinguish it from compile-contracts action's cache key which only caches retester. This prevents occasional "report-processor: command not found" for workflows using both actions, and also fixes an issue with restoring cache when the runner is `parity-large` and the cache was saved by a GitHub hosted ubuntu, due to `actions/cache` storing paths workspace-relative.