### PR TITLE
pin & configure Rust toolchain (1.93.0) and unbreak wasm runtime builds on Rust 1.96

### DIFF
--- a/.github/actions/require-binary/action.yaml
+++ b/.github/actions/require-binary/action.yaml
@@ -85,6 +85,8 @@ runs:
       run: |
         set -euo pipefail
 
+        rust_version="$(rustc --version 2>/dev/null || echo unknown)"
+
         request_hash="$(
           {
             printf 'repository=%s\n' "$REPOSITORY"
@@ -93,6 +95,7 @@ runs:
             printf 'no_default_features=%s\n' "$NO_DEFAULT_FEATURES"
             printf 'runner_os=%s\n' "$RUNNER_OS"
             printf 'runner_arch=%s\n' "$RUNNER_ARCH"
+            printf 'rust_version=%s\n' "$rust_version"
             printf 'features<<EOF\n%s\nEOF\n' "$FEATURES"
             printf 'packages<<EOF\n%s\nEOF\n' "$PACKAGES"
             printf 'env<<EOF\n%s\nEOF\n' "$REQUEST_ENV"

--- a/.github/actions/setup-benchmark-machine/action.yaml
+++ b/.github/actions/setup-benchmark-machine/action.yaml
@@ -2,6 +2,10 @@ name: Setup Benchmark Machine
 description: Sets up the machine for benchmarks by installing system packages and optional compiler binaries.
 
 inputs:
+  rust-toolchain:
+    description: The version of rust toolchain
+    required: false
+    default: "1.93.0"
   solc-version:
     description: The version of solc to install on the machine (e.g. v0.8.28)
     required: false
@@ -18,6 +22,7 @@ runs:
     - name: Setup the Rust Toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
+        toolchain: ${{ inputs.rust-toolchain }}
         cache: false
         target: wasm32-unknown-unknown,wasm32v1-none
         components: rust-src

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -56,6 +56,10 @@ on:
         description: Number of additional wallet keys to pre-seed at genesis
         required: true
         default: "201000"
+      rust-toolchain:
+        description: Rust toolchain version
+        required: true
+        default: "1.93.0"
       rust-log:
         description: The value to set to the `RUST_LOG` environment variable when the benchmarks run
         required: true
@@ -85,6 +89,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup the Machine
         uses: ./.github/actions/setup-benchmark-machine
+        with:
+          rust-toolchain: ${{ inputs.rust-toolchain }}
       - name: Build Retester
         uses: ./.github/actions/require-binary
         with:
@@ -104,6 +110,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup the Machine
         uses: ./.github/actions/setup-benchmark-machine
+        with:
+          rust-toolchain: ${{ inputs.rust-toolchain }}
       - name: Build chain-spec-generator
         uses: ./.github/actions/require-binary
         with:
@@ -116,7 +124,9 @@ jobs:
             polkadot
             asset-hub-polkadot
           no-default-features: true
-          env: RUSTFLAGS=-Awarnings
+          env: |
+            RUSTFLAGS=-Awarnings
+            WASM_BUILD_RUSTFLAGS=-Clink-arg=--allow-undefined
 
   build-polkadot-sdk:
     name: Build and Cache the Polkadot SDK Dependencies
@@ -126,6 +136,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup the Machine
         uses: ./.github/actions/setup-benchmark-machine
+        with:
+          rust-toolchain: ${{ inputs.rust-toolchain }}
       - name: Build polkadot
         uses: ./.github/actions/require-binary
         with:
@@ -137,7 +149,9 @@ jobs:
             polkadot
             polkadot-parachain-bin
             pallet-revive-eth-rpc
-          env: ${{ inputs.use-jit && 'RUSTFLAGS=-Awarnings --cfg revive_jit' || 'RUSTFLAGS=-Awarnings' }}
+          env: |
+            ${{ inputs.use-jit && 'RUSTFLAGS=-Awarnings --cfg revive_jit' || 'RUSTFLAGS=-Awarnings' }}
+            WASM_BUILD_RUSTFLAGS=-Clink-arg=--allow-undefined
 
   build-resolc:
     name: Build and Cache Resolc Binary
@@ -148,6 +162,7 @@ jobs:
       - name: Setup the Machine
         uses: ./.github/actions/setup-benchmark-machine
         with:
+          rust-toolchain: ${{ inputs.rust-toolchain }}
           resolc-repository: ${{ inputs.resolc-repository }}
           resolc-ref: ${{ inputs.resolc-ref }}
 
@@ -166,6 +181,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup the Machine
         uses: ./.github/actions/setup-benchmark-machine
+        with:
+          rust-toolchain: ${{ inputs.rust-toolchain }}
       - name: Build Retester
         uses: ./.github/actions/require-binary
         with:
@@ -225,6 +242,7 @@ jobs:
       - name: Setup the Machine
         uses: ./.github/actions/setup-benchmark-machine
         with:
+          rust-toolchain: ${{ inputs.rust-toolchain }}
           solc-version: ${{ inputs.solc-version }}
           resolc-repository: ${{ inputs.resolc-repository }}
           resolc-ref: ${{ inputs.resolc-ref }}
@@ -257,7 +275,9 @@ jobs:
             polkadot
             asset-hub-polkadot
           no-default-features: true
-          env: RUSTFLAGS=-Awarnings
+          env: |
+            RUSTFLAGS=-Awarnings
+            WASM_BUILD_RUSTFLAGS=-Clink-arg=--allow-undefined
       - name: Get Polkadot Binaries
         uses: ./.github/actions/require-binary
         with:
@@ -270,7 +290,9 @@ jobs:
             polkadot
             polkadot-parachain-bin
             pallet-revive-eth-rpc
-          env: ${{ inputs.use-jit && 'RUSTFLAGS=-Awarnings --cfg revive_jit' || 'RUSTFLAGS=-Awarnings' }}
+          env: |
+            ${{ inputs.use-jit && 'RUSTFLAGS=-Awarnings --cfg revive_jit' || 'RUSTFLAGS=-Awarnings' }}
+            WASM_BUILD_RUSTFLAGS=-Clink-arg=--allow-undefined
       - name: Set artifact name
         id: names
         env:


### PR DESCRIPTION
## Problem

Benchmark CI doesn't pin a Rust toolchain, so it always used latest. When **Rust 1.96** dropped, `build-polkadot-sdk` started failing while linking runtimes: `rust-lld: error: undefined symbol: ext_allocator_malloc_version_1`

1.96 [removed the implicit `--allow-undefined`](https://blog.rust-lang.org/2026/04/04/changes-to-webassembly-targets-and-handling-undefined-symbols/) that rustc used to pass to `wasm-ld`.

  ## Changes
  - **Configurable toolchain pin** — `rust-toolchain` workflow input (default `1.93.0`, matching what polkadot-sdk pins), threaded through `setup-benchmark-machine` to all build jobs.
  - **Re-add `--allow-undefined`** via `WASM_BUILD_RUSTFLAGS` on the two runtime-building jobs, so the build keeps working even if the toolchain is bumped to ≥1.96. Scoped to the wasm link only.
  - **Cache key now includes `rustc --version`**, so changing the toolchain forces a rebuild instead of serving a binary built by a different compiler.

**Test run**: https://github.com/paritytech/revive-differential-tests/actions/runs/26634592958