### PR TITLE
Fix revive-dev-node receipts issue

### DIFF
--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -37,7 +37,7 @@ pub(crate) mod internal_prelude {
 
     pub use alloy::{
         consensus::BlockHeader,
-        eips::BlockNumberOrTag,
+        eips::{BlockNumberOrTag, Encodable2718},
         genesis::{Genesis, GenesisAccount},
         network::{
             AnyNetwork, BlockResponse, Ethereum, EthereumWallet, Network, NetworkWallet,
@@ -68,6 +68,7 @@ pub(crate) mod internal_prelude {
         },
     };
     pub use anyhow::{Context as _, Result, bail};
+    pub use futures::FutureExt;
     pub use futures::StreamExt;
     pub use serde::{Deserialize, Deserializer, Serialize, Serializer};
     pub use serde_json::{self, Value, json};
@@ -75,7 +76,7 @@ pub(crate) mod internal_prelude {
     pub use serde_yaml_ng;
     pub use sp_core::crypto::Ss58Codec;
     pub use sp_runtime::AccountId32;
-    pub use subxt::{OnlineClient, PolkadotConfig};
+    pub use subxt::{OnlineClient, PolkadotConfig, tx::TxStatus};
     pub use tokio::sync::{OnceCell, Semaphore};
     pub use tokio::task::AbortHandle;
     pub use tokio::time::{interval, sleep, timeout};

--- a/crates/node/src/node_implementations/substrate.rs
+++ b/crates/node/src/node_implementations/substrate.rs
@@ -407,7 +407,7 @@ impl NodeApi for SubstrateNode {
 
             debug!("Submitted a substrate transaction");
 
-            timeout(Duration::from_mins(5), async move {
+            timeout(Duration::from_secs(5 * 60), async move {
                 loop {
                     match tx_progress.next().await {
                         Some(progress) => {

--- a/crates/node/src/node_implementations/substrate.rs
+++ b/crates/node/src/node_implementations/substrate.rs
@@ -275,22 +275,32 @@ impl SubstrateNode {
         Ok(String::from_utf8_lossy(&output).trim().to_string())
     }
 
-    async fn provider(&self) -> anyhow::Result<ConcreteProvider<Ethereum, Arc<EthereumWallet>>> {
-        self.provider
-            .get_or_try_init(|| async move {
-                construct_concurrency_limited_provider::<Ethereum, _>(
-                    self.rpc_url.as_str(),
-                    FallbackGasFiller::default()
-                        .with_fallback_mechanism(self.use_fallback_gas_filler),
-                    ChainIdFiller::default(),
-                    NonceFiller::new(self.nonce_manager.clone()),
-                    self.wallet.clone(),
-                )
+    fn provider(
+        &self,
+    ) -> FrameworkFuture<anyhow::Result<ConcreteProvider<Ethereum, Arc<EthereumWallet>>>> {
+        let provider = self.provider.clone();
+        let connection_string = self.rpc_url.clone();
+        let gas_filler =
+            FallbackGasFiller::default().with_fallback_mechanism(self.use_fallback_gas_filler);
+        let nonce_filler = NonceFiller::new(self.nonce_manager.clone());
+        let wallet = self.wallet.clone();
+
+        Box::pin(async move {
+            provider
+                .get_or_try_init(|| async move {
+                    construct_concurrency_limited_provider::<Ethereum, _>(
+                        &connection_string,
+                        gas_filler,
+                        ChainIdFiller::default(),
+                        nonce_filler,
+                        wallet,
+                    )
+                    .await
+                    .context("Failed to construct the provider")
+                })
                 .await
-                .context("Failed to construct the provider")
-            })
-            .await
-            .cloned()
+                .cloned()
+        })
     }
 
     pub fn node_genesis(
@@ -342,29 +352,9 @@ impl NodeApi for SubstrateNode {
     }
 
     fn provider(&self) -> revive_dt_common::futures::FrameworkFuture<anyhow::Result<DynProvider>> {
-        let provider = self.provider.clone();
-        let connection_string = self.rpc_url.clone();
-        let gas_filler =
-            FallbackGasFiller::default().with_fallback_mechanism(self.use_fallback_gas_filler);
-        let nonce_filler = NonceFiller::new(self.nonce_manager.clone());
-        let wallet = self.wallet.clone();
-
-        Box::pin(async move {
-            provider
-                .get_or_try_init(|| async move {
-                    construct_concurrency_limited_provider::<Ethereum, _>(
-                        &connection_string,
-                        gas_filler,
-                        ChainIdFiller::default(),
-                        nonce_filler,
-                        wallet,
-                    )
-                    .await
-                    .context("Failed to construct the provider")
-                })
-                .await
-                .map(|provider| provider.clone().erased())
-        })
+        Self::provider(self)
+            .map(|provider| provider.map(|provider| provider.erased()))
+            .boxed()
     }
 
     fn substrate_provider(

--- a/crates/node/src/node_implementations/substrate.rs
+++ b/crates/node/src/node_implementations/substrate.rs
@@ -351,6 +351,166 @@ impl NodeApi for SubstrateNode {
         EVMVersion::Cancun
     }
 
+    /// Submits a transaction and watches for it and if the transaction is dropped from the mempool
+    /// then it resubmits it again. Times out after 5 minutes if the transaction is not finalized in
+    /// that time frame.
+    fn submit_transaction(
+        &self,
+        transaction: TransactionRequest,
+    ) -> FrameworkFuture<Result<alloy::primitives::TxHash>> {
+        let provider = Self::provider(self);
+        let substrate_provider = NodeApi::substrate_provider(self);
+
+        let span = debug_span!(
+            "Revive dev node special transaction submission flow",
+            ethereum_tx_hash = tracing::field::Empty,
+            substrate_tx_hash = tracing::field::Empty,
+        );
+
+        let task = async move {
+            let provider = provider.await.context("Failed to get the provider")?;
+            let substrate_provider = substrate_provider
+                .expect("qed; this is a substrate node")
+                .await
+                .context("Failed to get the provider")?;
+
+            let signed_transaction = provider
+                .fill(transaction)
+                .await
+                .context("Failed to fill transaction")?
+                .try_into_envelope()
+                .context("Failed to construct envelope from filled transaction")?;
+            let ethereum_tx_hash = signed_transaction.tx_hash();
+            let payload = signed_transaction.encoded_2718();
+
+            Span::current().record(
+                "ethereum_tx_hash",
+                tracing::field::display(ethereum_tx_hash),
+            );
+
+            let call = revive_metadata::tx()
+                .revive()
+                .eth_transact(payload.to_vec())
+                .unvalidated();
+            let mut tx_progress = substrate_provider
+                .tx()
+                .create_unsigned(&call)
+                .context("Failed to create an unsigned transaction")?
+                .submit_and_watch()
+                .await
+                .context("Failed to submit the transaction through subxt")?;
+
+            Span::current().record(
+                "substrate_tx_hash",
+                tracing::field::debug(tx_progress.extrinsic_hash()),
+            );
+
+            debug!("Submitted a substrate transaction");
+
+            timeout(Duration::from_mins(5), async move {
+                loop {
+                    match tx_progress.next().await {
+                        Some(progress) => {
+                            let progress =
+                                progress.context("Failed to get the transaction progress update")?;
+
+                            // Logging the progress should be separate since I can't use the debug
+                            // formatting since it's way way way too verbose for anything that is
+                            // sane for logging.
+                            match &progress {
+                                TxStatus::Validated => debug!(
+                                    update = "Validated",
+                                    "Received a transaction progress update"
+                                ),
+                                TxStatus::Broadcasted => {
+                                    debug!(
+                                        update = "Broadcasted",
+                                        "Received a transaction progress update"
+                                    )
+                                },
+                                TxStatus::NoLongerInBestBlock => {
+                                    debug!(
+                                        update = "NoLongerInBestBlock",
+                                        "Received a transaction progress update"
+                                    )
+                                },
+                                TxStatus::InBestBlock(tx_in_block) => {
+                                    debug!(
+                                        update = "InBestBlock",
+                                        block_hash = %tx_in_block.block_hash(),
+                                        "Received a transaction progress update"
+                                    )
+                                },
+                                TxStatus::InFinalizedBlock(tx_in_block) => {
+                                    debug!(
+                                        update = "InFinalizedBlock",
+                                        block_hash = %tx_in_block.block_hash(),
+                                        "Received a transaction progress update"
+                                    )
+                                },
+                                TxStatus::Error { message } => {
+                                    debug!(update = "Error", message, "Received a transaction progress update")
+                                },
+                                TxStatus::Invalid { message } => {
+                                    debug!(update = "Invalid", message, "Received a transaction progress update")
+                                },
+                                TxStatus::Dropped { message } => {
+                                    debug!(update = "Dropped", message, "Received a transaction progress update")
+                                },
+                            }
+
+                            match progress {
+                                TxStatus::InFinalizedBlock(..) => {
+                                    debug!("Transaction has been finalized, stopping watching");
+                                    break Ok(());
+                                }
+                                TxStatus::Invalid { message } => {
+                                    error!(message, "Transaction is invalid!");
+                                    bail!("Encountered an invalid transaction. Message = {message}")
+                                }
+                                TxStatus::Error {  message } | TxStatus::Dropped {  message } => {
+                                    warn!(
+                                        message,
+                                        "Transaction was either dropped or encountered an error - resubmitting"
+                                    );
+                                    tx_progress = substrate_provider
+                                        .tx()
+                                        .create_unsigned(&call)
+                                        .context("Failed to create an unsigned transaction")?
+                                        .submit_and_watch()
+                                        .await
+                                        .context("Failed to resubmit the transaction through subxt")?
+                                },
+                                TxStatus::Validated
+                                | TxStatus::Broadcasted
+                                | TxStatus::NoLongerInBestBlock
+                                | TxStatus::InBestBlock(..) => {}
+                            }
+                        }
+                        None => {
+                            error!(
+                                "Stopped getting transaction progress updates before it was finalized"
+                            );
+                            tx_progress = substrate_provider
+                                .tx()
+                                .create_unsigned(&call)
+                                .context("Failed to create an unsigned transaction")?
+                                .submit_and_watch()
+                                .await
+                                .context("Failed to resubmit the transaction through subxt")?
+                        }
+                    }
+                }
+            })
+            .await
+            .context("Submission failed due to a timeout after watching for 5 minutes")??;
+
+            Ok(*ethereum_tx_hash)
+        }
+        .instrument(span);
+        Box::pin(task)
+    }
+
     fn provider(&self) -> revive_dt_common::futures::FrameworkFuture<anyhow::Result<DynProvider>> {
         Self::provider(self)
             .map(|provider| provider.map(|provider| provider.erased()))

--- a/crates/node/src/node_implementations/substrate.rs
+++ b/crates/node/src/node_implementations/substrate.rs
@@ -190,6 +190,10 @@ impl SubstrateNode {
                     .arg(u32::MAX.to_string())
                     .arg("--state-pruning")
                     .arg(NUMBER_OF_CACHED_BLOCKS.to_string())
+                    .arg("--pool-type")
+                    .arg("single-state")
+                    .arg("--rpc-max-subscriptions-per-connection")
+                    .arg(u32::MAX.to_string())
                     .env("RUST_LOG", self.node_logging_level.as_str())
                     .stdout(stdout_file)
                     .stderr(stderr_file);


### PR DESCRIPTION
# Description

This PR fixes some of the issues we've been seeing where we sometimes fail to get the receipt for a transaction we've submitted to the chain and which we know has been included in a block. This is a client side fix and we're waiting on the upstream issues related to this to be resolved.

- We spawn the revive-dev-node with `--pool-type single-state` as recommended by https://github.com/paritytech/polkadot-sdk/issues/10104 which helped reduce these issues a lot.
- We have updated the submission logic for the revive dev node to use `subxt` and to watch for the transaction status after submission and resubmit any transaction which has been dropped from the mem-pool.

# Future Work

We could further improve this on the client side but a fix upstream is needed. A potential improvement we could do is to resubmit the transaction again after 1 minute if we don't hear any kind of status update on it so there's always selecting between two futures to see which resolves first: the `tokio::time::sleep(Duration::from_secs(60))` future or the status update future. But again, we need a fix for this upstream since there isn't much more that retester can do in such cases.