### PR TITLE
Fix retester-eth-rpc race condition

### DIFF
--- a/crates/node-interaction/src/lib.rs
+++ b/crates/node-interaction/src/lib.rs
@@ -84,11 +84,28 @@ pub trait NodeApi {
         Box::pin(async move {
             let tx_hash = submission_future.await?;
             let provider = provider.await.context("Failed to get the provider")?;
-            provider
+            let receipt = provider
                 .get_transaction_receipt(tx_hash)
                 .await
                 .context("Failed to get the transaction receipt")?
-                .context("Failed to get the transaction receipt")
+                .context("Failed to get the transaction receipt")?;
+            let receipt_block_number = receipt
+                .block_number
+                .context("A receipt must have a block number")?;
+            tokio::time::timeout(Duration::from_secs(120), async move {
+                while provider
+                    .get_block_number()
+                    .await
+                    .context("Failed to get the block number")?
+                    < receipt_block_number
+                {
+                    tokio::time::sleep(Duration::from_millis(200)).await
+                }
+                Result::<(), anyhow::Error>::Ok(())
+            })
+            .await
+            .context("Waited 120 seconds for the rpc block to be updated but it wasn't")??;
+            Ok(receipt)
         })
     }
 


### PR DESCRIPTION
# Description

This PR fixes (I'm afraid of using this word now with how often we've tried to fix those issues and either fail or discover other reasons for why they happen) an issue which was reported by @xermicus and @elle-j where retester's results when running against the eth-rpc were indeterministic.

The previous PR (https://github.com/paritytech/revive-differential-tests/pull/295) fixed one concrete source of indeterminism which was caused by the pool type we were using for the `revive-dev-node` and with transactions disappearing from the node's mempool by changing the mem-pool type to be `single-state` (as recommended by the github issue linked in that PR) and also by adding transaction resubmission logic into retester itself if this case does occur. This did indeed fix the issues we saw around "attempted to get receipt but we couldn't do it within the timeout".

This other issue that we're seeing is indeterministic "OutOfGas" errors which sometimes happens and sometimes does not. I've run the tool locally multiple times and it didn't happen and have also had a few runs where it did happen. The "brute force" way of solving this problem of "let's just multiply all gas estimates by 10" doesn't work in this case for reasons that you'll read later on.

Before I describe the specific issue, let me just lay some background. When retester is executing transactions it's running in the following loop:

1. Fetch the next step.
1. Convert Metadata's step into a transaction.
1. Perform a gas estimate on the transaction.
1. Submit transaction
1. Wait for receipt
1. Run assertions
1. Loop

The eth-rpc's logic for handling of blocks (at least the one being used in resolc at the moment) is roughly the following:

1. Wait for a new block to arrive.
1. Process the block receipts adding them to the database (making them available)
1. Update the cached "latest block" number that it stores.
1. Loop

You can probably already see how the combination of these two things together leads to issues, but let me provide a concrete example of this. Say that we have a test case which is composed of two steps which require us to submit two transactions: `A`, and `B`, let's walk through how this race condition happens.

1. **Retester** does a gas estimate for transaction `A` against block `N` where block `N` is the currently latest block and gets a gas estimate back.
1. **Retester** constructs the transaction with the gas and submits it to the network and polls the eth-rpc for the receipt of the transaction.
1. **Eth-Rpc** is subscribed to new blocks being produced and gets a notification of block `N+1` which contains transaction `A`.
1. **Eth-Rpc** starts processing the block and begins by processing the receipt of transaction `A`, adding it to its database and making the receipt available to us.
1. **Retester** was polling for the receipt and is now finally able to get the receipt from the eth-rpc.
1. **Retester** assumes that since it has gotten the receipt that the state of the eth-rpc and the node has been updated and moves on to the next transaction.
1. **Retester** does a gas estimate for the next transaction: transaction `B`. It requests the estimate from the eth-rpc. Because the eth-rpc a) made the receipt available before updating it's latest block and b) has not finished the block processing yet, then the eth-rpc runs the gas estimate against block `N` which its internal state thinks is the latest block when it's in fact currently processing block `N+1`.
1. **Retester** gets a gas estimation for transaction `B` which was run against block `N` rather than `N+1`. In some cases, this would mean that the estimation trapped and retester went into the fallback logic, in other cases, it means that a different codepath was followed in the contract when estimating its gas and now we have received a gas estimate which didn't account for the state changes of transaction `A`.
1. **Eth-rpc** at some point finished processing this block and updates its internal state so that it has the latest block as `N+1`.
1. **Retester** submits transaction `B` to the network and awaits its receipt.
1. **Retester** as the eth-rpc has processes block `N+2` the receipt becomes available and we get it back saying that we encountered an `OutOfGas`.

```mermaid
sequenceDiagram
    participant Retester
    participant ETH RPC
    participant Node
    
    Retester ->> ETH RPC: Estimate gas for transaction A
    ETH RPC ->> ETH RPC: Get Latest Block, It's Block N
    ETH RPC ->> Node: Estimate Gas Against Block N
    ETH RPC -->> Retester: Send Gas Estimate Back

    Retester ->> ETH RPC: Send transaction
    ETH RPC ->> Node: Send transaction
    Node -->> ETH RPC: Done
    ETH RPC -->> Retester: Done
    
    Node ->>+ ETH RPC: New Block Event (Block N +1), Start Processing
    Retester ->> ETH RPC: Get transaction receipt for A
    ETH RPC --> ETH RPC: Process receipt from Block N + 1
    ETH RPC --> ETH RPC: Discover receipt of transaction A
    ETH RPC -->> Retester: Receipt for transaction A

    Retester ->> ETH RPC: Estimate gas for transaction B
    ETH RPC ->> ETH RPC: Get Latest Block, It's Block N
    ETH RPC ->> Node: Estimate Gas Against Block N
    ETH RPC -->> Retester: Send Gas Estimate Back

    Retester ->> ETH RPC: Send transaction
    ETH RPC ->> Node: Send transaction
    Node -->> ETH RPC: Done
    ETH RPC -->> Retester: Done

    ETH RPC ->> ETH RPC: Finish processing all receipts from Block N + 1 
    ETH RPC ->>- ETH RPC: Update the stored latest block from Block N + 1
```

A summary, this issue happens because the eth-rpc is not running the gas estimations against the true latest block but against what it thinks is the latest block at the time which might not actually be the latest block.

Some of the solutions considered for this are:
1. Making use of transactions in the eth-rpc so that all of the state updates from processing a block are atomic and are seen together.
1. Storing a separate "currently processing" field in the eth-rpc and gas estimations always get `latest_block.max(currently_processing)` if they specify block as `LatestBlock` which would allow for the correct latest block to be used even when a block is still being processed.
1. Using `subxt` for the gas estimations since we can tell from the client side what the latest block is and therefore can be sure that we're running gas estimations on the actual latest block.
1. Waiting for the eth-rpc's state to be updated after submitting any transaction such that we're sure that by the time we go to submit the next transaction that eth-rpc would include the block number of the actual latest block.

I chose to go with option 4 since it's a simpler option than 1, 2, or 3. Option 3 is quite nice but it doesn't work well with alloy providers and their filler logic and therefore integrating it into the codebase can be hard.

I have verified this by running the tool multiple times locally and I have not observed any "OutOfGas" errors since this change was made.
