### PR TITLE
Conditionally build polkadot-sdk packages in run-differential-tests action

### DIFF
--- a/.github/actions/compare-bytecode-hashes/action.yml
+++ b/.github/actions/compare-bytecode-hashes/action.yml
@@ -37,7 +37,22 @@ runs:
       shell: bash
       run: echo "path=${{ inputs.revive-differential-tests-path || 'revive-differential-tests' }}" >> "$GITHUB_OUTPUT"
 
+    - name: Resolve the report-processor cache key
+      id: report-processor-cache-key
+      shell: bash
+      run: |
+        sha=$(git -C "${{ steps.repo.outputs.path }}" rev-parse HEAD)
+        echo "key=report-processor-${{ runner.os }}-${{ runner.arch }}-${sha}" >> "$GITHUB_OUTPUT"
+
+    - name: Cache report-processor
+      id: report-processor-cache
+      uses: actions/cache@v5
+      with:
+        path: ~/.cargo/bin/report-processor${{ runner.os == 'Windows' && '.exe' || '' }}
+        key: ${{ steps.report-processor-cache-key.outputs.key }}
+
     - name: Install report-processor
+      if: ${{ steps.report-processor-cache.outputs.cache-hit != 'true' }}
       shell: bash
       run: cargo install --locked --path "${{ steps.repo.outputs.path }}/crates/report-processor"
 

--- a/.github/actions/export-bytecode-hashes/action.yml
+++ b/.github/actions/export-bytecode-hashes/action.yml
@@ -39,7 +39,22 @@ runs:
       shell: bash
       run: echo "path=${{ inputs.revive-differential-tests-path || 'revive-differential-tests' }}" >> "$GITHUB_OUTPUT"
 
+    - name: Resolve the report-processor cache key
+      id: report-processor-cache-key
+      shell: bash
+      run: |
+        sha=$(git -C "${{ steps.repo.outputs.path }}" rev-parse HEAD)
+        echo "key=report-processor-${{ runner.os }}-${{ runner.arch }}-${sha}" >> "$GITHUB_OUTPUT"
+
+    - name: Cache report-processor
+      id: report-processor-cache
+      uses: actions/cache@v5
+      with:
+        path: ~/.cargo/bin/report-processor${{ runner.os == 'Windows' && '.exe' || '' }}
+        key: ${{ steps.report-processor-cache-key.outputs.key }}
+
     - name: Install report-processor
+      if: ${{ steps.report-processor-cache.outputs.cache-hit != 'true' }}
       shell: bash
       run: cargo install --locked --path "${{ steps.repo.outputs.path }}/crates/report-processor"
 

--- a/.github/actions/run-differential-tests/action.yml
+++ b/.github/actions/run-differential-tests/action.yml
@@ -102,11 +102,19 @@ runs:
         curl -fL --retry 3 --retry-all-errors --connect-timeout 10 -o cache.tar.gz "https://github.com/paritytech/revive-differential-tests/releases/download/compilation-caches-v1.1/cache.tar.gz"
         tar -zxf cache.tar.gz -C ./workdir > /dev/null 2>&1
 
-    - name: Building the dependencies from the Polkadot SDK
+    - name: Building eth-rpc from the Polkadot SDK
       shell: bash
-      run: |
-        ${{ inputs['cargo-command'] }} build --locked --profile release -p pallet-revive-eth-rpc -p revive-dev-node --manifest-path ${{ inputs['polkadot-sdk-path'] }}/Cargo.toml
-        ${{ inputs['cargo-command'] }} build --locked --profile release --bin polkadot-omni-node --manifest-path ${{ inputs['polkadot-sdk-path'] }}/Cargo.toml
+      run: ${{ inputs['cargo-command'] }} build --locked --profile release -p pallet-revive-eth-rpc --manifest-path ${{ inputs['polkadot-sdk-path'] }}/Cargo.toml
+
+    - name: Building revive-dev-node from the Polkadot SDK
+      if: ${{ startsWith(inputs.platform, 'revive-dev-node') }}
+      shell: bash
+      run: ${{ inputs['cargo-command'] }} build --locked --profile release -p revive-dev-node --manifest-path ${{ inputs['polkadot-sdk-path'] }}/Cargo.toml
+
+    - name: Building polkadot-omni-node from the Polkadot SDK
+      if: ${{ startsWith(inputs.platform, 'polkadot-omni-node') }}
+      shell: bash
+      run: ${{ inputs['cargo-command'] }} build --locked --profile release --bin polkadot-omni-node --manifest-path ${{ inputs['polkadot-sdk-path'] }}/Cargo.toml
 
     - name: Resolve the retester cache key
       id: retester-cache-key


### PR DESCRIPTION
## Summary

Some packages such as `polkadot-omni-node` were unconditionally built in the run-differential-tests action. This PR updates it to be built conditionally based on platform input. It also caches report-processor for the export and compare bytecode hashes actions.