### PR TITLE
Use BufWriter for writing the report

### DIFF
--- a/crates/report/src/aggregator.rs
+++ b/crates/report/src/aggregator.rs
@@ -132,7 +132,7 @@ impl ReportAggregator {
                 .working_directory
                 .as_path()
                 .join(file_name);
-            let file = OpenOptions::new()
+            let writer = OpenOptions::new()
                 .create(true)
                 .write(true)
                 .truncate(true)
@@ -143,8 +143,9 @@ impl ReportAggregator {
                         "Failed to open report file for writing: {}",
                         file_path.display()
                     )
-                })?;
-            serde_json::to_writer_pretty(&file, &self.report).with_context(|| {
+                })
+                .map(BufWriter::new)?;
+            serde_json::to_writer_pretty(writer, &self.report).with_context(|| {
                 format!("Failed to serialize report JSON to {}", file_path.display())
             })?;
             tracing::info!(file_path = %file_path.display(), "Report has been written");

--- a/crates/report/src/lib.rs
+++ b/crates/report/src/lib.rs
@@ -21,6 +21,7 @@ pub(crate) mod internal_prelude {
 
     pub use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
     pub use std::fs::OpenOptions;
+    pub use std::io::BufWriter;
     pub use std::path::{Path, PathBuf};
     pub use std::sync::Arc;
     pub use std::time::{SystemTime, UNIX_EPOCH};


### PR DESCRIPTION
# Description

Small change to how we write the final report to a file by using a `BufWriter` instead of writing to the file directly which speeds up the file writing by a large amount.